### PR TITLE
Change default include features to minimal

### DIFF
--- a/tet/config/__init__.py
+++ b/tet/config/__init__.py
@@ -187,7 +187,7 @@ def create_configurator(*,
 
 def application_factory(factory_function: Callable[[Configurator], Any]=None,
                         configure_only=False,
-                        included_features=ALL_FEATURES,
+                        included_features=MINIMAL_FEATURES,
                         excluded_features=(),
                         package=None,
                         **extra_parameters):


### PR DESCRIPTION
Currently `application_factory` has `included_features=ALL_FEATURES` by default, which make `tet` dependent on `tonnikala`, so user might see surprising error like:
```
ModuleNotFoundError: No module named 'tonnikala'
```
We should leave the default as minimal and let user chooses which feature to include