### PR TITLE
Re-export pyramid_di DI primitives from tet.services (0.5.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Changes
 
 
+2026-05-28  Antti Haapala  <antti.haapala@anttipatterns.com>
+
+    * 0.5.0: ``tet.services`` now re-exports ``service``,
+      ``RequestScopedBaseService``, ``ApplicationScopedBaseService``,
+      ``BaseService`` and ``autowired`` from ``pyramid_di``. Application
+      code should import these from ``tet.services`` rather than reaching
+      into ``pyramid_di`` directly.
+
+
 2025-01-28  Antti Haapala  <antti.haapala@anttipatterns.com>
 
     * Add Python 3.12, 3.13, 3.14 support. Drop Python 3.6, 3.7 support.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ dev_requires = ["pytest"]
 
 setup(
     name="tet",
-    version="0.4.3-dev",
+    version="0.5.0",
     description="Unearthly intelligent batteries-included application framework built on Pyramid",
     long_description=README + "\n\n" + CHANGES,
     long_description_content_type="text/markdown",

--- a/tet/services/__init__.py
+++ b/tet/services/__init__.py
@@ -4,12 +4,18 @@ Dependency injection support for Tet applications.
 This module provides dependency injection via ``pyramid_di``. It is included
 automatically when using the ``services`` feature.
 
+The DI primitives (:func:`service`, :class:`RequestScopedBaseService`,
+:class:`ApplicationScopedBaseService`, :class:`BaseService`,
+:func:`autowired`) are re-exported here so application code can import
+them from a single, stable location -- ``tet.services`` -- rather than
+reaching into ``pyramid_di`` directly.
+
 Example
 -------
 
 Defining a service::
 
-    from pyramid_di import service, RequestScopedBaseService, autowired
+    from tet.services import service, RequestScopedBaseService, autowired
 
     @service()
     class UserService(RequestScopedBaseService):
@@ -36,7 +42,7 @@ Setup and scanning services::
 Using services in class-based views::
 
     from pyramid.view import view_config
-    from pyramid_di import autowired
+    from tet.services import autowired
     from myapp.services import UserService
 
     class UserViews:
@@ -60,6 +66,22 @@ Using services in function-based views::
         return user_service.get_user(request.matchdict["id"])
 """
 from pyramid.config import Configurator
+from pyramid_di import (  # noqa: F401
+    ApplicationScopedBaseService,
+    BaseService,
+    RequestScopedBaseService,
+    autowired,
+    service,
+)
+
+__all__ = [
+    "ApplicationScopedBaseService",
+    "BaseService",
+    "RequestScopedBaseService",
+    "autowired",
+    "includeme",
+    "service",
+]
 
 
 def includeme(config: Configurator) -> None:


### PR DESCRIPTION
## Summary

- `tet.services` now re-exports `service`, `RequestScopedBaseService`, `ApplicationScopedBaseService`, `BaseService` and `autowired` from `pyramid_di`, giving Tet applications a single, stable import location instead of reaching into `pyramid_di` directly.
- The module declares `__all__` and carries `# noqa: F401` on the import line so linters (pyflakes, ruff `F401`) won't flag the imports as unused.
- The docstring examples in `tet/services/__init__.py` are updated to import from `tet.services`.
- `CHANGES.md` gets a 0.5.0 entry; `setup.py` is bumped `0.4.3-dev` → `0.5.0`.

The runtime behaviour of `includeme` (which still just calls `config.include("pyramid_di")`) is unchanged — this is a pure additive change to the public API surface.

## Why

Application code (e.g. the projects generated from `interjektio-app-cookiecutter`) used to import `from tet.services import autowired`, which broke when `tet.services` was originally collapsed to a feature shim. Centralising the DI symbols back on `tet.services` is the single-stable-import-path story we want; users shouldn't need to know that DI is provided by `pyramid_di` under the hood.

## Test plan

- [x] Local smoke test: `from tet.services import service, autowired, RequestScopedBaseService, ApplicationScopedBaseService, BaseService, includeme` all resolve; `tet.services.autowired is pyramid_di.autowired`.
- [x] `pyflakes tet/services/__init__.py` clean.
- [x] `ruff check --select F,E,W tet/services/__init__.py` clean.
- [ ] CI green on this branch.