### PR TITLE
docs: ruff-format & compile-check examples; Tonnikala syntax; package guidance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,13 @@ repos:
         language: script
         files: ^docs/.*\.rst$
         pass_filenames: false
+      # Compile-check every code-block example (also enforced by pytest).
+      - id: compile-doc-examples
+        name: compile-check docs examples
+        entry: tools/doc_examples.py
+        language: script
+        files: ^docs/.*\.rst$
+        pass_filenames: false
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,17 @@ repos:
       - id: rstcheck
         additional_dependencies: ['rstcheck[sphinx,toml]']
 
+  # Keep the Python code-block examples in the docs ruff-formatted.
+  # Run tools/format_doc_examples.py (no --check) to apply the fixes.
+  - repo: local
+    hooks:
+      - id: format-doc-examples
+        name: ruff-format docs examples
+        entry: tools/format_doc_examples.py --check
+        language: script
+        files: ^docs/.*\.rst$
+        pass_filenames: false
+
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/docs/narr/configuration.rst
+++ b/docs/narr/configuration.rst
@@ -22,12 +22,14 @@ by default the wrapper returns a WSGI application built from it:
 
     from tet.config import application_factory, ALL_FEATURES, MINIMAL_FEATURES
 
+
     @application_factory(included_features=ALL_FEATURES)
     def main(config):
         """Tet application factory."""
         # Your application configuration
-        config.add_route('home', '/')
+        config.add_route("home", "/")
         config.scan()
+
 
     # The decorator can also be applied without arguments. In that case the
     # default is MINIMAL_FEATURES (no features are auto-included), so you add
@@ -35,8 +37,8 @@ by default the wrapper returns a WSGI application built from it:
     @application_factory
     def minimal_main(config):
         """Minimal Tet application."""
-        config.include('tet.renderers.json')  # Add features manually
-        config.add_route('api', '/api')
+        config.include("tet.renderers.json")  # Add features manually
+        config.add_route("api", "/api")
 
 The decorator accepts the following keyword arguments:
 
@@ -90,16 +92,17 @@ keyword-only:
 
     from tet.config import create_configurator
 
+
     def main(global_config, **settings):
         config = create_configurator(
             global_config=global_config,
             settings=settings,
-            included_features=['renderers.json', 'security.csrf'],
-            excluded_features=['i18n'],
+            included_features=["renderers.json", "security.csrf"],
+            excluded_features=["i18n"],
         )
 
         # Your configuration
-        config.add_route('home', '/')
+        config.add_route("home", "/")
         config.scan()
 
         return config.make_wsgi_app()
@@ -142,10 +145,7 @@ JSON Renderer Directives
     api_renderer = JSON()
 
     # Register with custom name
-    config.add_json_renderer(
-        renderer=api_renderer,
-        name='api_json'
-    )
+    config.add_json_renderer(renderer=api_renderer, name="api_json")
 
 **add_json_adapter**
   Register a type adapter for JSON serialization:
@@ -154,13 +154,15 @@ JSON Renderer Directives
 
     from decimal import Decimal
 
+
     def decimal_adapter(obj, request):
         return str(obj)
+
 
     config.add_json_adapter(
         for_=Decimal,
         adapter=decimal_adapter,
-        renderer='json'  # Optional, defaults to 'json'
+        renderer="json",  # Optional, defaults to 'json'
     )
 
 Authorization Directive
@@ -194,13 +196,11 @@ The CSRF module sets secure defaults but can be customized:
     def main(global_config, **settings):
         with Configurator(settings=settings) as config:
             # Include CSRF with custom options
-            config.include('tet.security.csrf')
+            config.include("tet.security.csrf")
 
             # Override CSRF settings if needed
             config.set_default_csrf_options(
-                require_csrf=True,
-                token='csrf_token',
-                header='X-CSRF-Token'
+                require_csrf=True, token="csrf_token", header="X-CSRF-Token"
             )
 
             return config.make_wsgi_app()
@@ -214,23 +214,18 @@ Customize the JSON renderer behavior:
 
     from pyramid.renderers import JSON
 
+
     def main(global_config, **settings):
         with Configurator(settings=settings) as config:
             # Include JSON renderer
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
 
             # Add custom adapters
-            config.add_json_adapter(
-                for_=MyModel,
-                adapter=lambda obj, req: obj.to_dict()
-            )
+            config.add_json_adapter(for_=MyModel, adapter=lambda obj, req: obj.to_dict())
 
             # Create specialized renderer
             api_renderer = JSON(sort_keys=True, indent=2)
-            config.add_json_renderer(
-                renderer=api_renderer,
-                name='pretty_json'
-            )
+            config.add_json_renderer(renderer=api_renderer, name="pretty_json")
 
             return config.make_wsgi_app()
 
@@ -288,10 +283,10 @@ Access settings in your application code:
         settings = request.registry.settings
 
         # Access configuration values
-        database_url = settings.get('sqlalchemy.url')
-        debug_mode = settings.get('debug', False)
+        database_url = settings.get("sqlalchemy.url")
+        debug_mode = settings.get("debug", False)
 
-        return {'debug': debug_mode}
+        return {"debug": debug_mode}
 
 Environment Configuration
 =========================
@@ -306,19 +301,21 @@ Development Configuration
     # development.py
     def main(global_config, **settings):
         # Development-specific settings
-        settings.update({
-            'debug': True,
-            'reload_templates': True,
-            'sqlalchemy.echo': True,
-        })
+        settings.update(
+            {
+                "debug": True,
+                "reload_templates": True,
+                "sqlalchemy.echo": True,
+            }
+        )
 
         with Configurator(settings=settings) as config:
-            config.include('tet.security.csrf')
-            config.include('tet.renderers.json')
+            config.include("tet.security.csrf")
+            config.include("tet.renderers.json")
 
             # Development-only includes
-            if settings.get('debug'):
-                config.include('pyramid_debugtoolbar')
+            if settings.get("debug"):
+                config.include("pyramid_debugtoolbar")
 
             return config.make_wsgi_app()
 
@@ -330,17 +327,19 @@ Production Configuration
     # production.py
     def main(global_config, **settings):
         # Production-specific settings
-        settings.update({
-            'debug': False,
-            'reload_templates': False,
-            'session.secure': True,
-            'session.httponly': True,
-        })
+        settings.update(
+            {
+                "debug": False,
+                "reload_templates": False,
+                "session.secure": True,
+                "session.httponly": True,
+            }
+        )
 
         with Configurator(settings=settings) as config:
-            config.include('tet.security.csrf')
-            config.include('tet.security.authorization')
-            config.include('tet.renderers.json')
+            config.include("tet.security.csrf")
+            config.include("tet.security.authorization")
+            config.include("tet.renderers.json")
 
             # Production-only security
             config.set_default_csrf_options(require_csrf=True)
@@ -355,18 +354,20 @@ Testing Configuration
     # testing.py
     def main(global_config, **settings):
         # Testing-specific settings
-        settings.update({
-            'debug': True,
-            'sqlalchemy.url': 'sqlite:///:memory:',
-            'csrf.disable': True,  # Disable CSRF for easier testing
-        })
+        settings.update(
+            {
+                "debug": True,
+                "sqlalchemy.url": "sqlite:///:memory:",
+                "csrf.disable": True,  # Disable CSRF for easier testing
+            }
+        )
 
         with Configurator(settings=settings) as config:
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
 
             # Conditional CSRF inclusion
-            if not settings.get('csrf.disable'):
-                config.include('tet.security.csrf')
+            if not settings.get("csrf.disable"):
+                config.include("tet.security.csrf")
 
             return config.make_wsgi_app()
 
@@ -384,10 +385,12 @@ Configure root factories and other components:
 
     from tet.sqlalchemy.factory import SQLARootFactory
 
+
     class MyRootFactory(SQLARootFactory):
         def supplier(self, item):
             # Implementation here
             pass
+
 
     def main(global_config, **settings):
         with Configurator(settings=settings) as config:
@@ -395,10 +398,10 @@ Configure root factories and other components:
             config.set_root_factory(MyRootFactory)
 
             # Configure based on settings
-            if settings.get('use_traversal'):
-                config.add_route('api', '/api/*traverse')
+            if settings.get("use_traversal"):
+                config.add_route("api", "/api/*traverse")
             else:
-                config.add_route('api', '/api/{action}')
+                config.add_route("api", "/api/{action}")
 
             return config.make_wsgi_app()
 
@@ -411,15 +414,17 @@ Configure services with pyramid_di:
 
     from pyramid_di import service
 
-    @service(name='mailer', scope='singleton')
+
+    @service(name="mailer", scope="singleton")
     def create_mailer(settings):
-        smtp_host = settings.get('mail.smtp.host', 'localhost')
+        smtp_host = settings.get("mail.smtp.host", "localhost")
         return MailerService(smtp_host)
+
 
     def main(global_config, **settings):
         with Configurator(settings=settings) as config:
-            config.include('pyramid_di')
-            config.include('tet.renderers.json')
+            config.include("pyramid_di")
+            config.include("tet.renderers.json")
 
             # Services are automatically available
             return config.make_wsgi_app()
@@ -437,8 +442,8 @@ Settings Validation
     def validate_settings(settings):
         """Validate required settings."""
         required = [
-            'sqlalchemy.url',
-            'session.secret',
+            "sqlalchemy.url",
+            "session.secret",
         ]
 
         missing = [key for key in required if not settings.get(key)]
@@ -446,8 +451,9 @@ Settings Validation
             raise ValueError(f"Missing required settings: {missing}")
 
         # Validate specific values
-        if len(settings.get('session.secret', '')) < 32:
+        if len(settings.get("session.secret", "")) < 32:
             raise ValueError("session.secret must be at least 32 characters")
+
 
     def main(global_config, **settings):
         # Validate configuration early
@@ -477,13 +483,13 @@ Settings Helper
             def get_bool(self, key, default=False):
                 value = self.settings.get(key, default)
                 if isinstance(value, str):
-                    return value.lower() in ('true', '1', 'yes', 'on')
+                    return value.lower() in ("true", "1", "yes", "on")
                 return bool(value)
 
             def get_int(self, key, default=0):
                 return int(self.settings.get(key, default))
 
-            def get_list(self, key, separator=',', default=None):
+            def get_list(self, key, separator=",", default=None):
                 value = self.settings.get(key, default or [])
                 if isinstance(value, str):
                     return [item.strip() for item in value.split(separator)]
@@ -502,26 +508,27 @@ Profile System
 .. code-block:: python
 
     PROFILES = {
-        'development': {
-            'debug': True,
-            'sqlalchemy.echo': True,
-            'reload_templates': True,
+        "development": {
+            "debug": True,
+            "sqlalchemy.echo": True,
+            "reload_templates": True,
         },
-        'testing': {
-            'debug': True,
-            'sqlalchemy.url': 'sqlite:///:memory:',
-            'csrf.disable': True,
+        "testing": {
+            "debug": True,
+            "sqlalchemy.url": "sqlite:///:memory:",
+            "csrf.disable": True,
         },
-        'production': {
-            'debug': False,
-            'session.secure': True,
-            'session.httponly': True,
-        }
+        "production": {
+            "debug": False,
+            "session.secure": True,
+            "session.httponly": True,
+        },
     }
+
 
     def main(global_config, **settings):
         # Load profile-specific settings
-        profile = settings.get('profile', 'development')
+        profile = settings.get("profile", "development")
         profile_settings = PROFILES.get(profile, {})
 
         # Merge settings with profile taking precedence

--- a/docs/narr/decorators.rst
+++ b/docs/narr/decorators.rst
@@ -172,8 +172,8 @@ Example
 
 
     report = Report(load_rows())
-    report.summary   # prints "computing summary..." and computes the dict
-    report.summary   # returns the cached dict; no print, no recompute
+    report.summary  # prints "computing summary..." and computes the dict
+    report.summary  # returns the cached dict; no print, no recompute
 
 Because caching uses the bound attribute name, you can rely on the cached value
 living under the attribute you actually access, which is what makes it suitable

--- a/docs/narr/i18n.rst
+++ b/docs/narr/i18n.rst
@@ -195,7 +195,7 @@ natural:
 
     <h1>$_("Welcome to our site!")</h1>
 
-    <button>${_("Save")}</button>
+    <button>$_("Save")</button>
 
 When you need to pass a mapping or a context, use braces to delimit the full
 expression:

--- a/docs/narr/i18n.rst
+++ b/docs/narr/i18n.rst
@@ -25,6 +25,7 @@ translation domain (your package name) automatically.
 
     from tet.config import application_factory
 
+
     @application_factory(included_features=["i18n"])
     def main(config):
         config.add_translation_dirs("myapp:locale")
@@ -56,6 +57,7 @@ pass the domain you want to use:
 .. code-block:: python
 
     from tet.i18n import configure_i18n
+
 
     def main(global_config, **settings):
         config = Configurator(settings=settings)
@@ -109,6 +111,7 @@ request's localizer.
 .. code-block:: python
 
     from pyramid.view import view_config
+
 
     @view_config(route_name="hello", renderer="json")
     def hello(request):
@@ -232,6 +235,7 @@ globals are available inside viewlet templates with no extra work:
 .. code-block:: python
 
     from tet.viewlet import viewlet
+
 
     @viewlet("myapp:templates/sidebar.tk")
     def sidebar(request):

--- a/docs/narr/introduction.rst
+++ b/docs/narr/introduction.rst
@@ -101,6 +101,7 @@ independently:
 
     from pyramid.config import Configurator
 
+
     def main(global_config, **settings):
         with Configurator(settings=settings) as config:
             # Include only the Tet features you need

--- a/docs/narr/json.rst
+++ b/docs/narr/json.rst
@@ -100,10 +100,7 @@ The enhanced renderer includes adapters for:
 
     from datetime import datetime, date
 
-    data = {
-        'created': datetime.now(),
-        'birthday': date(1990, 1, 1)
-    }
+    data = {"created": datetime.now(), "birthday": date(1990, 1, 1)}
     # Will serialize as:
     # {
     #     'created': '2024-01-15T10:30:00',
@@ -119,9 +116,10 @@ Enable the enhanced JSON renderer in your application:
 
     from pyramid.config import Configurator
 
+
     def main():
         with Configurator() as config:
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
             # Enhanced JSON renderer is now available
 
             return config.make_wsgi_app()
@@ -143,18 +141,17 @@ Use the ``add_json_adapter`` directive to register custom type adapters:
     from decimal import Decimal
     from pyramid.config import Configurator
 
+
     def decimal_adapter(obj, request):
         return str(obj)
 
+
     def main():
         with Configurator() as config:
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
 
             # Add custom adapter for Decimal
-            config.add_json_adapter(
-                for_=Decimal,
-                adapter=decimal_adapter
-            )
+            config.add_json_adapter(for_=Decimal, adapter=decimal_adapter)
 
             return config.make_wsgi_app()
 
@@ -167,18 +164,16 @@ You can register multiple JSON renderers with different names:
 
     from pyramid.renderers import JSON
 
+
     def main():
         with Configurator() as config:
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
 
             # Create a custom renderer for API responses
             api_renderer = JSON()
             api_renderer.add_adapter(MyModel, lambda obj, req: obj.to_dict())
 
-            config.add_json_renderer(
-                renderer=api_renderer,
-                name='api_json'
-            )
+            config.add_json_renderer(renderer=api_renderer, name="api_json")
 
             return config.make_wsgi_app()
 
@@ -186,9 +181,9 @@ Then use it in your views:
 
 .. code-block:: python
 
-    @view_config(route_name='api_endpoint', renderer='api_json')
+    @view_config(route_name="api_endpoint", renderer="api_json")
     def api_view(request):
-        return {'data': MyModel.query.all()}
+        return {"data": MyModel.query.all()}
 
 JSON in Views
 =============
@@ -200,12 +195,12 @@ Basic JSON Response
 
 .. code-block:: python
 
-    @view_config(route_name='api', renderer='json')
+    @view_config(route_name="api", renderer="json")
     def api_view(request):
         return {
-            'status': 'success',
-            'data': get_some_data(),
-            'timestamp': datetime.now()  # Automatically converted
+            "status": "success",
+            "data": get_some_data(),
+            "timestamp": datetime.now(),  # Automatically converted
         }
 
 Handling JSON Input
@@ -215,17 +210,17 @@ For processing JSON request bodies:
 
 .. code-block:: python
 
-    @view_config(route_name='api_post', request_method='POST', renderer='json')
+    @view_config(route_name="api_post", request_method="POST", renderer="json")
     def api_post_view(request):
         try:
             json_data = request.json_body
         except ValueError:
-            return {'error': 'Invalid JSON'}
+            return {"error": "Invalid JSON"}
 
         # Process the JSON data
         result = process_data(json_data)
 
-        return {'result': result}
+        return {"result": result}
 
 Error Handling
 --------------
@@ -236,12 +231,13 @@ Handle JSON-related errors gracefully:
 
     from pyramid.httpexceptions import HTTPBadRequest
 
-    @view_config(route_name='api', renderer='json')
+
+    @view_config(route_name="api", renderer="json")
     def api_view(request):
         try:
             data = request.json_body
         except ValueError as e:
-            raise HTTPBadRequest(json_body={'error': 'Invalid JSON: ' + str(e)})
+            raise HTTPBadRequest(json_body={"error": "Invalid JSON: " + str(e)})
 
         return process_data(data)
 
@@ -255,32 +251,29 @@ Performance Considerations
 
     from functools import lru_cache
 
+
     @lru_cache(maxsize=100)
     def get_cached_data():
         return expensive_data_operation()
 
-    @view_config(route_name='api', renderer='json')
+
+    @view_config(route_name="api", renderer="json")
     def api_view(request):
-        return {'data': get_cached_data()}
+        return {"data": get_cached_data()}
 
 **Large Data Sets**
   For large data sets, consider pagination or streaming:
 
 .. code-block:: python
 
-    @view_config(route_name='api', renderer='json')
+    @view_config(route_name="api", renderer="json")
     def api_view(request):
-        page = int(request.params.get('page', 1))
-        limit = int(request.params.get('limit', 20))
+        page = int(request.params.get("page", 1))
+        limit = int(request.params.get("limit", 20))
 
         data = get_paginated_data(page=page, limit=limit)
 
-        return {
-            'data': data,
-            'page': page,
-            'limit': limit,
-            'has_more': len(data) == limit
-        }
+        return {"data": data, "page": page, "limit": limit, "has_more": len(data) == limit}
 
 Best Practices
 ==============

--- a/docs/narr/json.rst
+++ b/docs/narr/json.rst
@@ -69,10 +69,10 @@ Use the safe JSON in your templates:
 .. code-block:: html
 
     <script>
-        var userData = ${safe_json|n};
+        var userData = $literal(safe_json);
     </script>
 
-The ``|n`` filter outputs the value without HTML-escaping in the Tonnikala template engine, which is what you want since ``js_safe_dumps`` has already produced a string that is safe to embed in a ``<script>`` element.
+``$literal(...)`` outputs the value without HTML-escaping in the Tonnikala template engine, which is what you want since ``js_safe_dumps`` has already produced a string that is safe to embed in a ``<script>`` element. (Tonnikala escapes every ``$`` interpolation by default; ``$literal`` is the deliberate opt-out for already-safe markup.)
 
 Enhanced JSON Renderer
 ======================

--- a/docs/narr/request_response.rst
+++ b/docs/narr/request_response.rst
@@ -38,6 +38,7 @@ That means importing from Tet gives you the genuine Pyramid classes:
 
     # These are the very same objects Pyramid hands you:
     from pyramid.request import Request as PyramidRequest
+
     assert Request is PyramidRequest
 
 There is currently **no** ``tet.request.Request`` subclass, no overridden
@@ -111,6 +112,7 @@ Tet's feature-based configuration:
 .. code-block:: python
 
     from tet.config import application_factory
+
 
     @application_factory(included_features=["i18n"])
     def main(config):

--- a/docs/narr/security.rst
+++ b/docs/narr/security.rst
@@ -37,7 +37,7 @@ In your templates, include CSRF tokens in forms:
 .. code-block:: html
 
     <form method="post" action="/submit">
-        <input type="hidden" name="csrf_token" value="${request.session.get_csrf_token()}">
+        <input type="hidden" name="csrf_token" value="$request.session.get_csrf_token()">
         <!-- Your form fields -->
         <input type="submit" value="Submit">
     </form>
@@ -167,7 +167,7 @@ Use Tet's JSON utilities to prevent XSS when embedding JSON in HTML:
     safe_json = js_safe_dumps(user_data)
 
     # In your template:
-    # <script>var userData = ${safe_json|n};</script>
+    # <script>var userData = $literal(safe_json);</script>
 
 The ``js_safe_dumps`` function escapes dangerous characters:
 

--- a/docs/narr/security.rst
+++ b/docs/narr/security.rst
@@ -18,9 +18,10 @@ To enable CSRF protection in your application:
 
     from pyramid.config import Configurator
 
+
     def main():
         with Configurator() as config:
-            config.include('tet.security.csrf')
+            config.include("tet.security.csrf")
             # CSRF protection is now enabled by default
             # with require_csrf=True
 
@@ -66,12 +67,13 @@ Traditional Pyramid authorization policies receive limited context. Tet's ``INew
     from tet.security.authorization import INewAuthorizationPolicy
     from zope.interface import implementer
 
+
     @implementer(INewAuthorizationPolicy)
     class MyAuthorizationPolicy:
         def permits(self, request, context, principals, permission):
             # Access to request object for richer authorization logic
-            if request.path.startswith('/admin/'):
-                return 'admin' in principals
+            if request.path.startswith("/admin/"):
+                return "admin" in principals
             return True
 
         def principals_allowed_by_permission(self, request, context, permission):
@@ -89,9 +91,10 @@ Register your authorization policy with Tet:
 
     from pyramid.config import Configurator
 
+
     def main():
         with Configurator() as config:
-            config.include('tet.security.authorization')
+            config.include("tet.security.authorization")
             # set_authorization_policy is added by the include above
             config.set_authorization_policy(MyAuthorizationPolicy())
 
@@ -122,6 +125,7 @@ The ``SQLARootFactory`` properly handles SQL exceptions and converts them to app
     from tet.sqlalchemy.factory import SQLARootFactory
     from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
     from sqlalchemy.exc import DataError
+
 
     class MyRootFactory(SQLARootFactory):
         def supplier(self, item):
@@ -206,10 +210,10 @@ Security Considerations
 .. code-block:: python
 
     settings = {
-        'session.secret': 'your-secret-key',
-        'session.secure': True,  # HTTPS only
-        'session.httponly': True,  # No JavaScript access
-        'session.samesite': 'Strict',  # CSRF protection
+        "session.secret": "your-secret-key",
+        "session.secure": True,  # HTTPS only
+        "session.httponly": True,  # No JavaScript access
+        "session.samesite": "Strict",  # CSRF protection
     }
 
 **HTTPS in Production**

--- a/docs/narr/services.rst
+++ b/docs/narr/services.rst
@@ -155,7 +155,7 @@ list, the equivalent explicit include is:
 
 .. code-block:: python
 
-    config.include("pyramid_di")        # or: config.include("tet.services")
+    config.include("pyramid_di")  # or: config.include("tet.services")
     config.scan_services("myapp.services")
 
 You can also register services imperatively, without the ``@service()``
@@ -167,9 +167,11 @@ interface or third-party type:
     # Register an already-constructed instance under a type/name.
     config.register_service(my_instance, SomeType)
 
+
     # Register a factory called with (context, request) to build the service.
     def make_session_service(context, request):
         return build_session(request)
+
 
     config.register_service_factory(make_session_service, Session)
 

--- a/docs/narr/sqlalchemy.rst
+++ b/docs/narr/sqlalchemy.rst
@@ -26,6 +26,7 @@ request, which is stored as ``self.request``:
     from sqlalchemy.orm import Session
     from tet.sqlalchemy.factory import SQLARootFactory
 
+
     class UserFactory(SQLARootFactory):
         def supplier(self, item):
             """Override this method to provide object lookup logic."""
@@ -46,10 +47,11 @@ Register your factory with a route (or as the global root factory):
 
     from pyramid.config import Configurator
 
+
     def main():
         with Configurator() as config:
             # As a per-route factory
-            config.add_route('user', '/users/{id}', factory=UserFactory)
+            config.add_route("user", "/users/{id}", factory=UserFactory)
 
             # Or as the global traversal root factory
             config.set_root_factory(UserFactory)
@@ -86,15 +88,16 @@ you:
     from sqlalchemy.orm import Session
     from tet.sqlalchemy.factory import SQLARootFactory
 
+
     class ApplicationRoot(SQLARootFactory):
         def supplier(self, item):
             session = self.request.find_service(Session)
 
-            if re.fullmatch(r'\d+', item):
+            if re.fullmatch(r"\d+", item):
                 # Numeric primary key
                 return session.query(MyModel).filter_by(id=int(item)).one()
 
-            if re.fullmatch(r'[a-f0-9-]{36}', item):
+            if re.fullmatch(r"[a-f0-9-]{36}", item):
                 # UUID
                 return session.query(MyModel).filter_by(uuid=item).one()
 
@@ -124,11 +127,12 @@ it cannot be imported), includes ``pyramid_di`` and ``pyramid_tm``, and sets
     # Create models using Tet's declarative base (Alembic-friendly naming)
     Base = declarative_base()
 
+
     @application_factory(included_features=ALL_FEATURES)
     def main(config):
         # Adds the setup_sqlalchemy directive and includes
         # pyramid_di and pyramid_tm
-        config.include('tet.sqlalchemy.simple')
+        config.include("tet.sqlalchemy.simple")
 
         # Build the engine from settings (sqlalchemy.* by default) and
         # register the request-scoped session service
@@ -211,11 +215,12 @@ The session is registered as a ``pyramid_di`` service keyed on the
     from pyramid.view import view_config
     from sqlalchemy.orm import Session
 
-    @view_config(route_name='items', renderer='json')
+
+    @view_config(route_name="items", renderer="json")
     def list_items(request):
         session = request.find_service(Session)
         items = session.query(MyModel).all()
-        return {'items': items}
+        return {"items": items}
 
 Because the service is registered with ``pyramid_di``, it can also be injected
 into a service or view class via ``autowired``:
@@ -225,6 +230,7 @@ into a service or view class via ``autowired``:
     from pyramid_di import autowired
     from sqlalchemy.orm import Session
 
+
     class ItemViews:
         # Resolved from the request-scoped Session service
         session: Session = autowired(Session)
@@ -232,10 +238,10 @@ into a service or view class via ``autowired``:
         def __init__(self, request):
             self.request = request
 
-        @view_config(route_name='items', renderer='json')
+        @view_config(route_name="items", renderer="json")
         def list_items(self):
             items = self.session.query(MyModel).all()
-            return {'items': items}
+            return {"items": items}
 
 If you registered a named database (``setup_sqlalchemy(name="reports")``), pass
 the same name when resolving: ``request.find_service(Session, name="reports")``.
@@ -278,8 +284,9 @@ returns the stored hash.
 
     Base = declarative_base()
 
+
     class User(UserPasswordMixin, Base):
-        __tablename__ = 'users'
+        __tablename__ = "users"
 
         id = Column(Integer, primary_key=True)
         username = Column(String(100), unique=True, nullable=False)
@@ -288,13 +295,13 @@ Using the mixin:
 
 .. code-block:: python
 
-    user = User(username='john')
-    user.password = 'secret123'        # hashed automatically on assignment
+    user = User(username="john")
+    user.password = "secret123"  # hashed automatically on assignment
 
-    user.password                      # -> the stored hash, not the plaintext
+    user.password  # -> the stored hash, not the plaintext
 
-    if user.validate_password('secret123'):
-        print('Password correct!')
+    if user.validate_password("secret123"):
+        print("Password correct!")
 
 ``validate_password(password)`` returns ``False`` when no password has been set
 (the stored hash is ``None``), and otherwise returns the result of
@@ -317,8 +324,9 @@ Custom ``__json__`` Method
 
     Base = declarative_base()
 
+
     class User(Base):
-        __tablename__ = 'users'
+        __tablename__ = "users"
 
         id = Column(Integer, primary_key=True)
         name = Column(String(50))
@@ -327,10 +335,10 @@ Custom ``__json__`` Method
 
         def __json__(self, request):
             return {
-                'id': self.id,
-                'name': self.name,
-                'email': self.email,
-                'created': self.created,  # datetime handled by Tet's renderer
+                "id": self.id,
+                "name": self.name,
+                "email": self.email,
+                "created": self.created,  # datetime handled by Tet's renderer
             }
 
 JSON Adapter
@@ -340,17 +348,19 @@ JSON Adapter
 
     from pyramid.config import Configurator
 
+
     def user_adapter(user, request):
         return {
-            'id': user.id,
-            'name': user.name,
-            'email': user.email,
-            'created': user.created,
+            "id": user.id,
+            "name": user.name,
+            "email": user.email,
+            "created": user.created,
         }
+
 
     def main():
         with Configurator() as config:
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
             config.add_json_adapter(for_=User, adapter=user_adapter)
 
             return config.make_wsgi_app()
@@ -366,11 +376,12 @@ column-projection queries can be returned directly:
     from pyramid.view import view_config
     from sqlalchemy.orm import Session
 
-    @view_config(route_name='user_summary', renderer='json')
+
+    @view_config(route_name="user_summary", renderer="json")
     def user_summary(request):
         session = request.find_service(Session)
         results = session.query(User.name, User.email).all()
-        return {'users': results}
+        return {"users": results}
 
 Testing with Databases
 ======================
@@ -389,15 +400,18 @@ types) over SQLite:
     from sqlalchemy.orm import sessionmaker
     from myapp.models import Base
 
-    @pytest.fixture(scope='session')
-    def engine():
-        return create_engine('postgresql+psycopg://user:pass@localhost/test')
 
-    @pytest.fixture(scope='session')
+    @pytest.fixture(scope="session")
+    def engine():
+        return create_engine("postgresql+psycopg://user:pass@localhost/test")
+
+
+    @pytest.fixture(scope="session")
     def tables(engine):
         Base.metadata.create_all(engine)
         yield
         Base.metadata.drop_all(engine)
+
 
     @pytest.fixture
     def dbsession(engine, tables):
@@ -422,8 +436,9 @@ mock ``find_service`` accordingly:
     from myapp.models import MyModel
     from myapp.root import MyRootFactory
 
+
     def test_root_factory_success(dbsession):
-        obj = MyModel(name='test')
+        obj = MyModel(name="test")
         dbsession.add(obj)
         dbsession.commit()
 
@@ -433,13 +448,14 @@ mock ``find_service`` accordingly:
         root = MyRootFactory(request)
         assert root[str(obj.id)] == obj
 
+
     def test_root_factory_not_found(dbsession):
         request = Mock()
         request.find_service.return_value = dbsession
 
         root = MyRootFactory(request)
         with pytest.raises(KeyError):
-            root['999999']
+            root["999999"]
 
 Best Practices
 ==============

--- a/docs/narr/static.rst
+++ b/docs/narr/static.rst
@@ -156,9 +156,9 @@ the chain of attribute access and the method call as a single unit:
 
 .. code-block:: html
 
-    <link href="${request.static_url('myapp:static/style.css')}" rel="stylesheet">
-    <script src="${request.static_url('myapp:static/app.js')}"></script>
-    <img src="${request.static_url('myapp:static/img/logo.png')}" alt="Logo">
+    <link href="$request.static_url('myapp:static/style.css')" rel="stylesheet">
+    <script src="$request.static_url('myapp:static/app.js')"></script>
+    <img src="$request.static_url('myapp:static/img/logo.png')" alt="Logo">
 
 At render time these expand to URLs such as::
 
@@ -175,7 +175,7 @@ renderer:
 
 .. code-block:: python
 
-    @view_config(renderer="myapp:templates/index.html")
+    @view_config(renderer="myapp:templates/index.tk")
     def index(request):
         return {
             "stylesheet_url": request.static_url("myapp:static/style.css"),
@@ -193,6 +193,6 @@ See also
 --------
 
 - :doc:`templating` -- writing Tonnikala templates and using ``$``
-  interpolation, including expressions like ``${request.static_url(...)}``.
+  interpolation, including expressions like ``$request.static_url(...)``.
 - :doc:`configuration` -- the application factory, ``config.include`` and
   registering directives during configuration.

--- a/docs/narr/templating.rst
+++ b/docs/narr/templating.rst
@@ -31,6 +31,7 @@ directly on the configurator:
 
     from pyramid.config import Configurator
 
+
     def main(global_config, **settings):
         config = Configurator(settings=settings)
         config.include("tet.renderers.tonnikala")
@@ -53,6 +54,7 @@ instead of including it by hand:
 
     from tet.config import application_factory
 
+
     @application_factory(included_features=["renderers.tonnikala"])
     def main(config):
         config.add_route("home", "/")
@@ -73,6 +75,7 @@ template.
 .. code-block:: python
 
     from pyramid.view import view_config
+
 
     @view_config(route_name="home", renderer="templates/home.tk")
     def home(request):
@@ -206,6 +209,7 @@ With the feature-based factory, request the i18n feature instead:
 .. code-block:: python
 
     from tet.config import application_factory
+
 
     @application_factory(included_features=["renderers.tonnikala.i18n"])
     def main(config):

--- a/docs/narr/testing.rst
+++ b/docs/narr/testing.rst
@@ -52,13 +52,13 @@ Two markers are available:
 
     import pytest
 
+
     @pytest.mark.slow
-    def test_expensive_operation():
-        ...
+    def test_expensive_operation(): ...
+
 
     @pytest.mark.integration
-    def test_full_request_cycle(app):
-        ...
+    def test_full_request_cycle(app): ...
 
 Coverage is available through ``pytest-cov`` (installed by both the ``test``
 and ``dev`` extras)::
@@ -149,9 +149,7 @@ module sets ``require_csrf=True``:
 
         includeme(pyramid_config)
 
-        pyramid_config.set_default_csrf_options.assert_called_once_with(
-            require_csrf=True
-        )
+        pyramid_config.set_default_csrf_options.assert_called_once_with(require_csrf=True)
 
 Testing Views
 =============

--- a/docs/narr/utilities.rst
+++ b/docs/narr/utilities.rst
@@ -49,8 +49,8 @@ Standard Base64
 
     from tet.util.base64 import Base64
 
-    encoded = Base64.encode(b"hello")   # returns bytes
-    decoded = Base64.decode(encoded)    # returns b"hello"
+    encoded = Base64.encode(b"hello")  # returns bytes
+    decoded = Base64.decode(encoded)  # returns b"hello"
 
 ``Base64.encode`` wraps :func:`base64.b64encode` and returns ``bytes``;
 ``Base64.decode`` wraps :func:`base64.b64decode`. ``Base64.normalize`` is a
@@ -71,7 +71,7 @@ decode and tolerates common transcription mistakes.
     from tet.util.base64 import CrockfordBase32
 
     encoded = CrockfordBase32.encode(b"hello")  # returns str
-    decoded = CrockfordBase32.decode(encoded)    # returns bytes
+    decoded = CrockfordBase32.decode(encoded)  # returns bytes
 
     # Ambiguous characters are normalized: O -> 0, I/L -> 1
     CrockfordBase32.normalize("O1L")  # "011"
@@ -125,10 +125,10 @@ exploded into their characters.
     from tet.util.collections import flatten
 
     nested = [1, [2, 3, [4, 5]], 6]
-    list(flatten(nested))            # [1, 2, 3, 4, 5, 6]
+    list(flatten(nested))  # [1, 2, 3, 4, 5, 6]
 
     with_strings = ["hello", ["world", ["!"]]]
-    list(flatten(with_strings))      # ["hello", "world", "!"]
+    list(flatten(with_strings))  # ["hello", "world", "!"]
 
 Path Utilities
 ==============
@@ -178,16 +178,20 @@ is returned unchanged.
 
     export, __all__ = exporter()
 
+
     @export
     def my_public_function():
         pass
+
 
     @export
     class MyPublicClass:
         pass
 
+
     def _private_function():
         pass
+
 
     # __all__ == ["my_public_function", "MyPublicClass"]
 
@@ -215,6 +219,7 @@ A snippet file ``snippets/create_user.py`` looks like:
 
     def run(username, email):
         from myapp.models import User
+
         session = env["request"].dbsession
         user = User(username=username, email=email)
         session.add(user)

--- a/docs/narr/viewlets.rst
+++ b/docs/narr/viewlets.rst
@@ -242,7 +242,7 @@ before-render subscriber:
         <img src="$user.avatar_url" alt="$user.display_name">
         <span class="name">$user.display_name</span>
         <py:if test="is_self">
-            <span class="badge">${_('You')}</span>
+            <span class="badge">$_('You')</span>
         </py:if>
     </div>
 
@@ -254,7 +254,7 @@ itself by calling back through the ``viewlets`` global:
     <aside class="sidebar">
         $literal(viewlets.user_card(current_user))
         <p class="notifications">
-            ${_('Unread')}: $unread_count
+            $_('Unread'): $unread_count
         </p>
     </aside>
 
@@ -264,7 +264,7 @@ Finally, dropping the sidebar into a page layout:
 
     <body>
         <main>
-            ${literal(content)}
+            $literal(content)
         </main>
         $literal(viewlets.sidebar())
     </body>

--- a/docs/narr/views.rst
+++ b/docs/narr/views.rst
@@ -65,6 +65,7 @@ A plain function view looks exactly like it does in Pyramid:
 
     from tet.view import view_config
 
+
     @view_config(route_name="home", renderer="templates/home.html")
     def home_view(request):
         return {"title": "Welcome to Tet"}
@@ -99,6 +100,7 @@ way you would in any other ``pyramid_di`` service.
     from tet.view import ServiceViews, view_config
     from pyramid_di import autowired
 
+
     class UserViews(ServiceViews):
         # A request-scoped service injected by pyramid_di.
         user_service = autowired(UserService)
@@ -126,6 +128,7 @@ method of the class:
 .. code-block:: python
 
     from tet.view import view_config, view_defaults, ServiceViews
+
 
     @view_defaults(route_name="account", renderer="json")
     class AccountViews(ServiceViews):
@@ -188,6 +191,7 @@ classes) with dynamic lookups (implemented in ``_lookup``):
 
     from tet.view import BaseController, expose
 
+
     class UserController(BaseController):
         def __init__(self, request):
             self.request = request
@@ -247,6 +251,7 @@ Two behaviours are worth remembering:
 
     from tet.view import BaseController, expose
 
+
     class ArticleController(BaseController):
         def __init__(self, request):
             self.request = request
@@ -289,12 +294,13 @@ minimal setup looks like:
 
     from pyramid.config import Configurator
 
+
     def main(global_config, **settings):
         with Configurator(settings=settings) as config:
-            config.include("pyramid_di")          # required for ServiceViews
+            config.include("pyramid_di")  # required for ServiceViews
             config.add_route("users", "/users")
             config.add_route("user", "/users/{id}")
-            config.scan("myapp.views")            # picks up view_config / expose
+            config.scan("myapp.views")  # picks up view_config / expose
             return config.make_wsgi_app()
 
 For traversal controllers, also set your ``RootController`` as the root factory

--- a/docs/narr/views.rst
+++ b/docs/narr/views.rst
@@ -66,7 +66,7 @@ A plain function view looks exactly like it does in Pyramid:
     from tet.view import view_config
 
 
-    @view_config(route_name="home", renderer="templates/home.html")
+    @view_config(route_name="home", renderer="templates/home.tk")
     def home_view(request):
         return {"title": "Welcome to Tet"}
 
@@ -261,7 +261,7 @@ Two behaviours are worth remembering:
             # Default view for this context: /articles/<id>/
             return {"article": self.__name__}
 
-        @expose(renderer="templates/comments.html", request_method="GET")
+        @expose(renderer="templates/comments.tk", request_method="GET")
         def comments(self):
             # Named view: /articles/<id>/comments
             return {"comments": []}

--- a/docs/tutorials/database_tutorial.rst
+++ b/docs/tutorials/database_tutorial.rst
@@ -20,7 +20,7 @@ Create your database models and configuration:
     from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, Boolean
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import relationship
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     Base = declarative_base()
 
@@ -32,7 +32,7 @@ Create your database models and configuration:
         username = Column(String(50), unique=True, nullable=False)
         email = Column(String(100), unique=True, nullable=False)
         password_hash = Column(String(128))
-        created_at = Column(DateTime, default=datetime.utcnow)
+        created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
         is_active = Column(Boolean, default=True)
 
         # Relationships
@@ -56,7 +56,7 @@ Create your database models and configuration:
         title = Column(String(200), nullable=False)
         content = Column(Text)
         author_id = Column(Integer, ForeignKey("users.id"))
-        created_at = Column(DateTime, default=datetime.utcnow)
+        created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
         is_published = Column(Boolean, default=False)
 
         # Relationships

--- a/docs/tutorials/database_tutorial.rst
+++ b/docs/tutorials/database_tutorial.rst
@@ -24,8 +24,9 @@ Create your database models and configuration:
 
     Base = declarative_base()
 
+
     class User(Base):
-        __tablename__ = 'users'
+        __tablename__ = "users"
 
         id = Column(Integer, primary_key=True)
         username = Column(String(50), unique=True, nullable=False)
@@ -35,39 +36,40 @@ Create your database models and configuration:
         is_active = Column(Boolean, default=True)
 
         # Relationships
-        posts = relationship('Post', back_populates='author')
+        posts = relationship("Post", back_populates="author")
 
         def __json__(self, request):
             """JSON serialization for Tet's renderer."""
             return {
-                'id': self.id,
-                'username': self.username,
-                'email': self.email,
-                'created_at': self.created_at,
-                'is_active': self.is_active
+                "id": self.id,
+                "username": self.username,
+                "email": self.email,
+                "created_at": self.created_at,
+                "is_active": self.is_active,
             }
 
+
     class Post(Base):
-        __tablename__ = 'posts'
+        __tablename__ = "posts"
 
         id = Column(Integer, primary_key=True)
         title = Column(String(200), nullable=False)
         content = Column(Text)
-        author_id = Column(Integer, ForeignKey('users.id'))
+        author_id = Column(Integer, ForeignKey("users.id"))
         created_at = Column(DateTime, default=datetime.utcnow)
         is_published = Column(Boolean, default=False)
 
         # Relationships
-        author = relationship('User', back_populates='posts')
+        author = relationship("User", back_populates="posts")
 
         def __json__(self, request):
             return {
-                'id': self.id,
-                'title': self.title,
-                'content': self.content,
-                'author_id': self.author_id,
-                'created_at': self.created_at,
-                'is_published': self.is_published
+                "id": self.id,
+                "title": self.title,
+                "content": self.content,
+                "author_id": self.author_id,
+                "created_at": self.created_at,
+                "is_published": self.is_published,
             }
 
 Database Engine Setup
@@ -80,20 +82,23 @@ Database Engine Setup
     from sqlalchemy.orm import sessionmaker
     from models import Base
 
+
     def get_engine(settings):
         """Create database engine from settings."""
         return create_engine(
-            settings['sqlalchemy.url'],
-            echo=settings.get('sqlalchemy.echo', False),
-            pool_size=int(settings.get('sqlalchemy.pool_size', 10)),
-            max_overflow=int(settings.get('sqlalchemy.max_overflow', 20)),
-            pool_timeout=int(settings.get('sqlalchemy.pool_timeout', 30)),
-            pool_recycle=int(settings.get('sqlalchemy.pool_recycle', 3600))
+            settings["sqlalchemy.url"],
+            echo=settings.get("sqlalchemy.echo", False),
+            pool_size=int(settings.get("sqlalchemy.pool_size", 10)),
+            max_overflow=int(settings.get("sqlalchemy.max_overflow", 20)),
+            pool_timeout=int(settings.get("sqlalchemy.pool_timeout", 30)),
+            pool_recycle=int(settings.get("sqlalchemy.pool_recycle", 3600)),
         )
+
 
     def get_session_factory(engine):
         """Create session factory."""
         return sessionmaker(bind=engine)
+
 
     def initialize_database(engine):
         """Initialize database tables."""
@@ -116,12 +121,13 @@ Tet's SQLAlchemy Integration
     # Create declarative base using Tet's helper
     Base = declarative_base()
 
+
     @application_factory(included_features=ALL_FEATURES)
     def main(config):
         """Tet application factory with database support."""
 
         # Include Tet's simple SQLAlchemy setup
-        config.include('tet.sqlalchemy.simple')
+        config.include("tet.sqlalchemy.simple")
 
         # Setup SQLAlchemy - automatically configures:
         # - pyramid_di service registration
@@ -130,9 +136,9 @@ Tet's SQLAlchemy Integration
         config.setup_sqlalchemy()
 
         # Routes and views
-        config.add_route('users', '/users')
-        config.add_route('user', '/users/{id}')
-        config.scan('views')
+        config.add_route("users", "/users")
+        config.add_route("user", "/users/{id}")
+        config.scan("views")
 
 Settings Configuration
 ----------------------
@@ -175,24 +181,26 @@ Basic Root Factory
     from models import User, Post
     from sqlalchemy.orm.exc import NoResultFound
 
+
     class UserRootFactory(SQLARootFactory):
         """Root factory for user resources."""
 
         def supplier(self, item):
             """Look up user by ID."""
-            session = self.request.find_service(name='dbsession')
+            session = self.request.find_service(name="dbsession")
             try:
                 return session.query(User).filter_by(id=int(item)).one()
             except (NoResultFound, ValueError):
                 # These exceptions are converted to KeyError (404)
                 raise
 
+
     class PostRootFactory(SQLARootFactory):
         """Root factory for post resources."""
 
         def supplier(self, item):
             """Look up post by ID or slug."""
-            session = self.request.find_service(name='dbsession')
+            session = self.request.find_service(name="dbsession")
 
             try:
                 # Try numeric ID first
@@ -215,17 +223,17 @@ Multi-Model Root Factory
 
         def supplier(self, item):
             """Route to appropriate model based on item format."""
-            session = self.request.find_service(name='dbsession')
+            session = self.request.find_service(name="dbsession")
 
             # Handle different patterns
-            if item.startswith('user-'):
+            if item.startswith("user-"):
                 user_id = item[5:]  # Remove 'user-' prefix
                 try:
                     return session.query(User).filter_by(id=int(user_id)).one()
                 except (NoResultFound, ValueError):
                     raise
 
-            elif item.startswith('post-'):
+            elif item.startswith("post-"):
                 post_id = item[5:]  # Remove 'post-' prefix
                 try:
                     return session.query(Post).filter_by(id=int(post_id)).one()
@@ -253,8 +261,8 @@ Configure traversal with root factories:
             config.set_root_factory(ApplicationRootFactory)
 
             # Add traversal routes
-            config.add_route('user_detail', '/users/*traverse')
-            config.add_route('post_detail', '/posts/*traverse')
+            config.add_route("user_detail", "/users/*traverse")
+            config.add_route("post_detail", "/posts/*traverse")
 
             return config.make_wsgi_app()
 
@@ -275,23 +283,24 @@ User Management Views
     from sqlalchemy.orm import Session
     from models import User
 
+
     class UserViews:
         """User management views with autowired dependencies."""
 
         # Database session automatically injected via pyramid_di
         session: Session = autowired()
 
-        @view_config(route_name='users', request_method='GET', renderer='json')
+        @view_config(route_name="users", request_method="GET", renderer="json")
         def list_users(self, request):
             """List all users."""
             # Pagination
-            page = int(request.params.get('page', 1))
-            per_page = int(request.params.get('per_page', 20))
+            page = int(request.params.get("page", 1))
+            per_page = int(request.params.get("per_page", 20))
 
             query = self.session.query(User).filter_by(is_active=True)
 
             # Apply filters
-            if 'search' in request.params:
+            if "search" in request.params:
                 search = f"%{request.params['search']}%"
                 query = query.filter(User.username.ilike(search))
 
@@ -300,66 +309,67 @@ User Management Views
             users = query.offset((page - 1) * per_page).limit(per_page).all()
 
             return {
-                'users': users,  # Automatically serialized by Tet
-                'pagination': {
-                    'page': page,
-                    'per_page': per_page,
-                    'total': total,
-                    'pages': (total + per_page - 1) // per_page
-                }
+                "users": users,  # Automatically serialized by Tet
+                "pagination": {
+                    "page": page,
+                    "per_page": per_page,
+                    "total": total,
+                    "pages": (total + per_page - 1) // per_page,
+                },
             }
 
-        @view_config(route_name='user', request_method='GET', renderer='json')
+        @view_config(route_name="user", request_method="GET", renderer="json")
         def get_user(self, request):
             """Get single user by ID."""
-            user_id = request.matchdict['id']
+            user_id = request.matchdict["id"]
 
             try:
                 user = self.session.query(User).filter_by(id=int(user_id)).one()
-                return {'user': user}
+                return {"user": user}
             except (NoResultFound, ValueError):
                 raise HTTPNotFound("User not found")
 
-        @view_config(route_name='users', request_method='POST', renderer='json')
+        @view_config(route_name="users", request_method="POST", renderer="json")
         def create_user(self, request):
             """Create new user."""
             data = request.json_body
 
             # Validation
-            if not data.get('username') or not data.get('email'):
+            if not data.get("username") or not data.get("email"):
                 raise HTTPBadRequest("Username and email are required")
 
             # Check for existing user
-            existing = self.session.query(User).filter(
-                (User.username == data['username']) |
-                (User.email == data['email'])
-            ).first()
+            existing = (
+                self.session.query(User)
+                .filter((User.username == data["username"]) | (User.email == data["email"]))
+                .first()
+            )
 
             if existing:
                 raise HTTPBadRequest("Username or email already exists")
 
             # Create user
             user = User(
-                username=data['username'],
-                email=data['email'],
-                password_hash=hash_password(data.get('password', ''))
+                username=data["username"],
+                email=data["email"],
+                password_hash=hash_password(data.get("password", "")),
             )
 
             self.session.add(user)
             # No manual commit needed - pyramid_tm handles it automatically
 
-            return {'user': user, 'message': 'User created successfully'}
+            return {"user": user, "message": "User created successfully"}
 
 Relationship Handling
 ---------------------
 
 .. code-block:: python
 
-    @view_config(route_name='user_posts', renderer='json')
+    @view_config(route_name="user_posts", renderer="json")
     def get_user_posts(request):
         """Get posts by user."""
-        user_id = request.matchdict['user_id']
-        session = request.find_service(name='dbsession')
+        user_id = request.matchdict["user_id"]
+        session = request.find_service(name="dbsession")
 
         try:
             user = session.query(User).filter_by(id=int(user_id)).one()
@@ -367,16 +377,14 @@ Relationship Handling
             raise HTTPNotFound("User not found")
 
         # Get user's posts with eager loading
-        posts = session.query(Post).filter_by(
-            author_id=user.id,
-            is_published=True
-        ).order_by(Post.created_at.desc()).all()
+        posts = (
+            session.query(Post)
+            .filter_by(author_id=user.id, is_published=True)
+            .order_by(Post.created_at.desc())
+            .all()
+        )
 
-        return {
-            'user': user,
-            'posts': posts,
-            'post_count': len(posts)
-        }
+        return {"user": user, "posts": posts, "post_count": len(posts)}
 
 Complex Queries
 ---------------
@@ -385,47 +393,58 @@ Complex Queries
 
     from sqlalchemy import func, desc
 
-    @view_config(route_name='user_stats', renderer='json')
+
+    @view_config(route_name="user_stats", renderer="json")
     def user_statistics(request):
         """Get user statistics."""
-        session = request.find_service(name='dbsession')
+        session = request.find_service(name="dbsession")
 
         # Complex query with aggregations
-        stats = session.query(
-            User.id,
-            User.username,
-            func.count(Post.id).label('post_count'),
-            func.max(Post.created_at).label('last_post_date')
-        ).outerjoin(Post).group_by(User.id).all()
+        stats = (
+            session.query(
+                User.id,
+                User.username,
+                func.count(Post.id).label("post_count"),
+                func.max(Post.created_at).label("last_post_date"),
+            )
+            .outerjoin(Post)
+            .group_by(User.id)
+            .all()
+        )
 
         # The results are automatically JSON-serializable
-        return {'user_stats': stats}
+        return {"user_stats": stats}
 
-    @view_config(route_name='popular_posts', renderer='json')
+
+    @view_config(route_name="popular_posts", renderer="json")
     def popular_posts(request):
         """Get popular posts with author info."""
-        session = request.find_service(name='dbsession')
+        session = request.find_service(name="dbsession")
 
         # Join query with eager loading
-        posts = session.query(Post).join(User).filter(
-            Post.is_published == True
-        ).order_by(desc(Post.created_at)).limit(10).all()
+        posts = (
+            session.query(Post)
+            .join(User)
+            .filter(Post.is_published == True)
+            .order_by(desc(Post.created_at))
+            .limit(10)
+            .all()
+        )
 
         # Custom serialization including author info
         result = []
         for post in posts:
-            result.append({
-                'id': post.id,
-                'title': post.title,
-                'content': post.content[:200] + '...',  # Truncate
-                'created_at': post.created_at,
-                'author': {
-                    'id': post.author.id,
-                    'username': post.author.username
+            result.append(
+                {
+                    "id": post.id,
+                    "title": post.title,
+                    "content": post.content[:200] + "...",  # Truncate
+                    "created_at": post.created_at,
+                    "author": {"id": post.author.id, "username": post.author.username},
                 }
-            })
+            )
 
-        return {'posts': result}
+        return {"posts": result}
 
 Transaction Management
 ======================
@@ -442,7 +461,7 @@ With Tet's SQLAlchemy setup, transactions are handled automatically:
     @application_factory(included_features=ALL_FEATURES)
     def main(config):
         """Tet automatically includes pyramid_tm."""
-        config.include('tet.sqlalchemy.simple')
+        config.include("tet.sqlalchemy.simple")
         config.setup_sqlalchemy()
 
         # pyramid_tm is automatically included and configured
@@ -458,29 +477,29 @@ Your views don't need to manage transactions manually:
 
 .. code-block:: python
 
-    @view_config(route_name='complex_operation', renderer='json')
+    @view_config(route_name="complex_operation", renderer="json")
     def complex_database_operation(request):
         """Complex operation with automatic transaction management."""
         session = request.find_service(Session)
 
         # All operations happen in one transaction
         # Create user
-        user = User(username='newuser', email='new@example.com')
+        user = User(username="newuser", email="new@example.com")
         session.add(user)
         session.flush()  # Get the ID without committing
 
         # Create initial post
         post = Post(
-            title='Welcome Post',
-            content='Welcome to the platform!',
+            title="Welcome Post",
+            content="Welcome to the platform!",
             author_id=user.id,
-            is_published=True
+            is_published=True,
         )
         session.add(post)
 
         # If view returns successfully, transaction commits automatically
         # If any exception is raised, transaction rolls back automatically
-        return {'message': 'Operation completed successfully', 'user': user}
+        return {"message": "Operation completed successfully", "user": user}
 
 Handling Transaction Rollbacks
 ------------------------------
@@ -491,12 +510,13 @@ To trigger a rollback, raise an HTTP exception:
 
     from pyramid.httpexceptions import HTTPBadRequest
 
-    @view_config(route_name='conditional_operation', renderer='json')
+
+    @view_config(route_name="conditional_operation", renderer="json")
     def conditional_operation(request):
         session = request.find_service(Session)
 
         # Do some work
-        user = User(username='test')
+        user = User(username="test")
         session.add(user)
 
         # Check some condition
@@ -505,27 +525,27 @@ To trigger a rollback, raise an HTTP exception:
             raise HTTPBadRequest("Validation failed")
 
         # If we reach here, transaction will commit automatically
-        return {'user': user}
+        return {"user": user}
 
 Bulk Operations
 ---------------
 
 .. code-block:: python
 
-    @view_config(route_name='bulk_import', request_method='POST', renderer='json')
+    @view_config(route_name="bulk_import", request_method="POST", renderer="json")
     def bulk_import_users(request):
         """Bulk import users efficiently."""
-        session = request.find_service(name='dbsession')
-        users_data = request.json_body.get('users', [])
+        session = request.find_service(name="dbsession")
+        users_data = request.json_body.get("users", [])
 
         try:
             # Bulk insert for better performance
             user_objects = []
             for user_data in users_data:
                 user = User(
-                    username=user_data['username'],
-                    email=user_data['email'],
-                    password_hash=hash_password(user_data.get('password', ''))
+                    username=user_data["username"],
+                    email=user_data["email"],
+                    password_hash=hash_password(user_data.get("password", "")),
                 )
                 user_objects.append(user)
 
@@ -534,8 +554,8 @@ Bulk Operations
             session.commit()
 
             return {
-                'message': f'Successfully imported {len(user_objects)} users',
-                'count': len(user_objects)
+                "message": f"Successfully imported {len(user_objects)} users",
+                "count": len(user_objects),
             }
 
         except Exception as e:
@@ -556,29 +576,32 @@ Simple Migration System
     from sqlalchemy import text
 
     MIGRATIONS = {
-        '001_add_user_bio': """
+        "001_add_user_bio": """
             ALTER TABLE users ADD COLUMN bio TEXT;
         """,
-        '002_add_post_slug': """
+        "002_add_post_slug": """
             ALTER TABLE posts ADD COLUMN slug VARCHAR(200);
             CREATE INDEX idx_posts_slug ON posts(slug);
         """,
-        '003_add_timestamps': """
+        "003_add_timestamps": """
             ALTER TABLE users ADD COLUMN updated_at TIMESTAMP;
             ALTER TABLE posts ADD COLUMN updated_at TIMESTAMP;
-        """
+        """,
     }
+
 
     def run_migrations(engine):
         """Run pending migrations."""
         with engine.connect() as conn:
             # Create migrations table if it doesn't exist
-            conn.execute(text("""
+            conn.execute(
+                text("""
                 CREATE TABLE IF NOT EXISTS migrations (
                     id VARCHAR(255) PRIMARY KEY,
                     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
-            """))
+            """)
+            )
 
             # Get applied migrations
             result = conn.execute(text("SELECT id FROM migrations"))
@@ -589,9 +612,10 @@ Simple Migration System
                 if migration_id not in applied:
                     print(f"Running migration: {migration_id}")
                     conn.execute(text(sql))
-                    conn.execute(text(
-                        "INSERT INTO migrations (id) VALUES (:id)"
-                    ), {'id': migration_id})
+                    conn.execute(
+                        text("INSERT INTO migrations (id) VALUES (:id)"),
+                        {"id": migration_id},
+                    )
                     conn.commit()
 
 Using Alembic
@@ -622,19 +646,22 @@ Database Test Setup
     from sqlalchemy.orm import sessionmaker
     from models import Base, User, Post
 
-    @pytest.fixture(scope='session')
+
+    @pytest.fixture(scope="session")
     def engine():
         """Create test database engine."""
-        return create_engine('sqlite:///:memory:', echo=False)
+        return create_engine("sqlite:///:memory:", echo=False)
 
-    @pytest.fixture(scope='session')
+
+    @pytest.fixture(scope="session")
     def tables(engine):
         """Create all tables for testing."""
         Base.metadata.create_all(engine)
         yield
         Base.metadata.drop_all(engine)
 
-    @pytest.fixture(scope='function')
+
+    @pytest.fixture(scope="function")
     def dbsession(engine, tables):
         """Create database session for each test."""
         Session = sessionmaker(bind=engine)
@@ -643,13 +670,12 @@ Database Test Setup
         session.rollback()
         session.close()
 
+
     @pytest.fixture
     def sample_user(dbsession):
         """Create sample user for testing."""
         user = User(
-            username='testuser',
-            email='test@example.com',
-            password_hash='hashed_password'
+            username="testuser", email="test@example.com", password_hash="hashed_password"
         )
         dbsession.add(user)
         dbsession.commit()
@@ -669,42 +695,43 @@ Testing Views with Database
         request = DummyRequest()
         request.find_service = lambda name: dbsession
         request.json_body = {
-            'username': 'newuser',
-            'email': 'new@example.com',
-            'password': 'password123'
+            "username": "newuser",
+            "email": "new@example.com",
+            "password": "password123",
         }
 
         # Test the view
         result = create_user(request)
 
-        assert result['message'] == 'User created successfully'
-        assert result['user'].username == 'newuser'
+        assert result["message"] == "User created successfully"
+        assert result["user"].username == "newuser"
 
         # Verify in database
-        user = dbsession.query(User).filter_by(username='newuser').first()
+        user = dbsession.query(User).filter_by(username="newuser").first()
         assert user is not None
-        assert user.email == 'new@example.com'
+        assert user.email == "new@example.com"
+
 
     def test_user_posts(dbsession, sample_user):
         from views.users import get_user_posts
         from pyramid.testing import DummyRequest
 
         # Create test posts
-        post1 = Post(title='Post 1', author_id=sample_user.id, is_published=True)
-        post2 = Post(title='Post 2', author_id=sample_user.id, is_published=False)
+        post1 = Post(title="Post 1", author_id=sample_user.id, is_published=True)
+        post2 = Post(title="Post 2", author_id=sample_user.id, is_published=False)
         dbsession.add_all([post1, post2])
         dbsession.commit()
 
         # Test the view
         request = DummyRequest()
         request.find_service = lambda name: dbsession
-        request.matchdict = {'user_id': str(sample_user.id)}
+        request.matchdict = {"user_id": str(sample_user.id)}
 
         result = get_user_posts(request)
 
-        assert result['user'].id == sample_user.id
-        assert len(result['posts']) == 1  # Only published posts
-        assert result['posts'][0].title == 'Post 1'
+        assert result["user"].id == sample_user.id
+        assert len(result["posts"]) == 1  # Only published posts
+        assert result["posts"][0].title == "Post 1"
 
 Testing Root Factories
 ----------------------
@@ -726,7 +753,7 @@ Testing Root Factories
 
         # Test not found
         with pytest.raises(KeyError):
-            root['999']
+            root["999"]
 
 Performance Optimization
 ========================
@@ -740,18 +767,24 @@ Query Optimization
 
     from sqlalchemy.orm import joinedload, selectinload
 
-    @view_config(route_name='optimized_posts', renderer='json')
+
+    @view_config(route_name="optimized_posts", renderer="json")
     def optimized_posts_view(request):
         """Optimized post loading with eager loading."""
-        session = request.find_service(name='dbsession')
+        session = request.find_service(name="dbsession")
 
         # Eager load relationships to avoid N+1 queries
-        posts = session.query(Post).options(
-            joinedload(Post.author),  # Join load for one-to-one/many-to-one
-            selectinload(Post.comments)  # Select load for one-to-many
-        ).filter_by(is_published=True).all()
+        posts = (
+            session.query(Post)
+            .options(
+                joinedload(Post.author),  # Join load for one-to-one/many-to-one
+                selectinload(Post.comments),  # Select load for one-to-many
+            )
+            .filter_by(is_published=True)
+            .all()
+        )
 
-        return {'posts': posts}
+        return {"posts": posts}
 
 Connection Pooling
 ------------------
@@ -761,15 +794,15 @@ Connection Pooling
     def get_engine(settings):
         """Configure engine with optimized connection pooling."""
         return create_engine(
-            settings['sqlalchemy.url'],
+            settings["sqlalchemy.url"],
             # Connection pool settings
-            pool_size=20,           # Number of connections to maintain
-            max_overflow=50,        # Additional connections beyond pool_size
-            pool_timeout=30,        # Seconds to wait for connection
-            pool_recycle=3600,      # Recycle connections after 1 hour
+            pool_size=20,  # Number of connections to maintain
+            max_overflow=50,  # Additional connections beyond pool_size
+            pool_timeout=30,  # Seconds to wait for connection
+            pool_recycle=3600,  # Recycle connections after 1 hour
             # Query optimization
-            echo=False,             # Don't log SQL in production
-            echo_pool=False,        # Don't log pool events
+            echo=False,  # Don't log SQL in production
+            echo_pool=False,  # Don't log pool events
         )
 
 Query Caching
@@ -778,6 +811,7 @@ Query Caching
 .. code-block:: python
 
     from functools import lru_cache
+
 
     @lru_cache(maxsize=100)
     def get_popular_tags():

--- a/docs/tutorials/json_tutorial.rst
+++ b/docs/tutorials/json_tutorial.rst
@@ -37,7 +37,7 @@ Built-in Type Support
 
 .. code-block:: python
 
-    from datetime import datetime, date
+    from datetime import datetime, date, timezone
     from pyramid.view import view_config
 
 
@@ -128,7 +128,7 @@ Create adapters for your SQLAlchemy models:
         username = Column(String(50), unique=True)
         email = Column(String(100))
         password_hash = Column(String(128))  # Sensitive data
-        created_at = Column(DateTime, default=datetime.utcnow)
+        created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
         is_active = Column(Boolean, default=True)
 
 
@@ -272,7 +272,7 @@ Use Tet's ``js_safe_dumps`` function:
     # {"message": "\\u003c/script\\u003e\\u003cscript\\u003ealert('XSS')\\u003c/script\\u003e"}
 
 
-    @view_config(route_name="user_page", renderer="mytemplate.pt")
+    @view_config(route_name="user_page", renderer="mytemplate.tk")
     def user_page_view(request):
         user_data = {
             "name": request.user.name,
@@ -288,7 +288,7 @@ Use Tet's ``js_safe_dumps`` function:
 Template Integration
 --------------------
 
-In your Chameleon template:
+In your Tonnikala template:
 
 .. code-block:: html
 
@@ -302,7 +302,7 @@ In your Chameleon template:
 
         <script>
             // Safe JSON embedding - no XSS risk
-            var userData = ${user_json|n};
+            var userData = $literal(user_json);
 
             // Use the data safely
             document.getElementById('user-profile').innerHTML =
@@ -337,7 +337,7 @@ Handle complex nested objects:
         title = Column(String(200))
         content = Column(Text)
         author_id = Column(Integer, ForeignKey("users.id"))
-        created_at = Column(DateTime, default=datetime.utcnow)
+        created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
         # Relationship
         author = relationship("User", back_populates="posts")
@@ -399,6 +399,8 @@ Standardize error responses:
 
 .. code-block:: python
 
+    from datetime import datetime, timezone
+
     from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound
 
 
@@ -416,7 +418,7 @@ Standardize error responses:
                 "message": error.message,
                 "code": error.code,
                 "details": error.details,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         }
 

--- a/docs/tutorials/json_tutorial.rst
+++ b/docs/tutorials/json_tutorial.rst
@@ -18,10 +18,11 @@ Enable Tet's JSON renderer in your application:
 
     from pyramid.config import Configurator
 
+
     def main():
         with Configurator() as config:
             # Include Tet's enhanced JSON renderer
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
 
             return config.make_wsgi_app()
 
@@ -39,14 +40,16 @@ Built-in Type Support
     from datetime import datetime, date
     from pyramid.view import view_config
 
-    @view_config(route_name='api_data', renderer='json')
+
+    @view_config(route_name="api_data", renderer="json")
     def api_data_view(request):
         return {
-            'timestamp': datetime.now(),           # Automatically converted
-            'birthday': date(1990, 5, 15),        # Automatically converted
-            'message': 'Hello, World!',
-            'count': 42
+            "timestamp": datetime.now(),  # Automatically converted
+            "birthday": date(1990, 5, 15),  # Automatically converted
+            "message": "Hello, World!",
+            "count": 42,
         }
+
 
     # Output:
     # {
@@ -63,18 +66,19 @@ The JSON renderer automatically handles SQLAlchemy query results:
 
 .. code-block:: python
 
-    @view_config(route_name='user_stats', renderer='json')
+    @view_config(route_name="user_stats", renderer="json")
     def user_stats(request):
         session = request.dbsession
 
         # Named tuple results are automatically serializable
-        stats = session.query(
-            User.name,
-            User.email,
-            func.count(Post.id).label('post_count')
-        ).outerjoin(Post).group_by(User.id).all()
+        stats = (
+            session.query(User.name, User.email, func.count(Post.id).label("post_count"))
+            .outerjoin(Post)
+            .group_by(User.id)
+            .all()
+        )
 
-        return {'user_stats': stats}  # Automatically converted to list of dicts
+        return {"user_stats": stats}  # Automatically converted to list of dicts
 
 Custom JSON Adapters
 ====================
@@ -89,17 +93,20 @@ Simple Type Adapters
     from decimal import Decimal
     from uuid import UUID
 
+
     def decimal_adapter(obj, request):
         """Convert Decimal to string to avoid precision loss."""
         return str(obj)
+
 
     def uuid_adapter(obj, request):
         """Convert UUID to string."""
         return str(obj)
 
+
     def main():
         with Configurator() as config:
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
 
             # Add custom adapters
             config.add_json_adapter(for_=Decimal, adapter=decimal_adapter)
@@ -115,7 +122,7 @@ Create adapters for your SQLAlchemy models:
 .. code-block:: python
 
     class User(Base):
-        __tablename__ = 'users'
+        __tablename__ = "users"
 
         id = Column(Integer, primary_key=True)
         username = Column(String(50), unique=True)
@@ -124,16 +131,18 @@ Create adapters for your SQLAlchemy models:
         created_at = Column(DateTime, default=datetime.utcnow)
         is_active = Column(Boolean, default=True)
 
+
     def user_adapter(user, request):
         """Safe user serialization - excludes sensitive data."""
         return {
-            'id': user.id,
-            'username': user.username,
-            'email': user.email,
-            'created_at': user.created_at,  # Automatically converted by Tet
-            'is_active': user.is_active
+            "id": user.id,
+            "username": user.username,
+            "email": user.email,
+            "created_at": user.created_at,  # Automatically converted by Tet
+            "is_active": user.is_active,
             # Note: password_hash is deliberately excluded
         }
+
 
     # Register the adapter
     config.add_json_adapter(for_=User, adapter=user_adapter)
@@ -147,23 +156,21 @@ Adapters receive the request object, allowing for context-aware serialization:
 
     def user_context_adapter(user, request):
         """Context-aware user serialization."""
-        base_data = {
-            'id': user.id,
-            'username': user.username,
-            'is_active': user.is_active
-        }
+        base_data = {"id": user.id, "username": user.username, "is_active": user.is_active}
 
         # Include email only for authenticated users
         if request.authenticated_userid:
-            base_data['email'] = user.email
+            base_data["email"] = user.email
 
         # Include admin data for admin users
-        if 'group:admin' in request.effective_principals:
-            base_data.update({
-                'created_at': user.created_at,
-                'last_login': user.last_login,
-                'login_count': user.login_count
-            })
+        if "group:admin" in request.effective_principals:
+            base_data.update(
+                {
+                    "created_at": user.created_at,
+                    "last_login": user.last_login,
+                    "login_count": user.login_count,
+                }
+            )
 
         return base_data
 
@@ -179,33 +186,25 @@ Specialized Renderers
 
     from pyramid.renderers import JSON
 
+
     def main():
         with Configurator() as config:
-            config.include('tet.renderers.json')
+            config.include("tet.renderers.json")
 
             # Create specialized renderers
 
             # Pretty-printed JSON for debugging
             debug_renderer = JSON(indent=2, sort_keys=True)
-            config.add_json_renderer(
-                renderer=debug_renderer,
-                name='debug_json'
-            )
+            config.add_json_renderer(renderer=debug_renderer, name="debug_json")
 
             # Compact JSON for APIs
-            api_renderer = JSON(separators=(',', ':'))
-            config.add_json_renderer(
-                renderer=api_renderer,
-                name='api_json'
-            )
+            api_renderer = JSON(separators=(",", ":"))
+            config.add_json_renderer(renderer=api_renderer, name="api_json")
 
             # Public API renderer with limited data
             public_renderer = JSON()
             public_renderer.add_adapter(User, user_public_adapter)
-            config.add_json_renderer(
-                renderer=public_renderer,
-                name='public_json'
-            )
+            config.add_json_renderer(renderer=public_renderer, name="public_json")
 
             return config.make_wsgi_app()
 
@@ -214,17 +213,19 @@ Using Different Renderers
 
 .. code-block:: python
 
-    @view_config(route_name='debug_data', renderer='debug_json')
+    @view_config(route_name="debug_data", renderer="debug_json")
     def debug_view(request):
-        return {'complex_data': get_complex_debug_data()}
+        return {"complex_data": get_complex_debug_data()}
 
-    @view_config(route_name='api_data', renderer='api_json')
+
+    @view_config(route_name="api_data", renderer="api_json")
     def api_view(request):
-        return {'users': User.query.all()}
+        return {"users": User.query.all()}
 
-    @view_config(route_name='public_api', renderer='public_json')
+
+    @view_config(route_name="public_api", renderer="public_json")
     def public_api_view(request):
-        return {'users': User.query.filter_by(is_public=True).all()}
+        return {"users": User.query.filter_by(is_public=True).all()}
 
 Safe JavaScript Serialization
 =============================
@@ -270,18 +271,19 @@ Use Tet's ``js_safe_dumps`` function:
     safe_json = js_safe_dumps(user_input)
     # {"message": "\\u003c/script\\u003e\\u003cscript\\u003ealert('XSS')\\u003c/script\\u003e"}
 
-    @view_config(route_name='user_page', renderer='mytemplate.pt')
+
+    @view_config(route_name="user_page", renderer="mytemplate.pt")
     def user_page_view(request):
         user_data = {
-            'name': request.user.name,
-            'preferences': request.user.preferences,
-            'bio': request.user.bio  # Could contain dangerous content
+            "name": request.user.name,
+            "preferences": request.user.preferences,
+            "bio": request.user.bio,  # Could contain dangerous content
         }
 
         # Safe for HTML embedding
         safe_user_json = js_safe_dumps(user_data)
 
-        return {'user_json': safe_user_json}
+        return {"user_json": safe_user_json}
 
 Template Integration
 --------------------
@@ -329,39 +331,37 @@ Handle complex nested objects:
 .. code-block:: python
 
     class BlogPost(Base):
-        __tablename__ = 'posts'
+        __tablename__ = "posts"
 
         id = Column(Integer, primary_key=True)
         title = Column(String(200))
         content = Column(Text)
-        author_id = Column(Integer, ForeignKey('users.id'))
+        author_id = Column(Integer, ForeignKey("users.id"))
         created_at = Column(DateTime, default=datetime.utcnow)
 
         # Relationship
-        author = relationship('User', back_populates='posts')
-        comments = relationship('Comment', back_populates='post')
+        author = relationship("User", back_populates="posts")
+        comments = relationship("Comment", back_populates="post")
+
 
     def post_adapter(post, request):
         """Serialize blog post with nested objects."""
         return {
-            'id': post.id,
-            'title': post.title,
-            'content': post.content,
-            'created_at': post.created_at,
-            'author': {
-                'id': post.author.id,
-                'username': post.author.username
-            },
-            'comment_count': len(post.comments),
-            'comments': [
+            "id": post.id,
+            "title": post.title,
+            "content": post.content,
+            "created_at": post.created_at,
+            "author": {"id": post.author.id, "username": post.author.username},
+            "comment_count": len(post.comments),
+            "comments": [
                 {
-                    'id': comment.id,
-                    'content': comment.content,
-                    'author': comment.author.username,
-                    'created_at': comment.created_at
+                    "id": comment.id,
+                    "content": comment.content,
+                    "author": comment.author.username,
+                    "created_at": comment.created_at,
                 }
                 for comment in post.comments[:5]  # Limit to recent comments
-            ]
+            ],
         }
 
 Pagination-Aware JSON
@@ -373,23 +373,23 @@ Handle paginated results:
 
     def paginated_adapter(query_result, request):
         """Adapter for paginated query results."""
-        page = int(request.params.get('page', 1))
-        per_page = int(request.params.get('per_page', 20))
+        page = int(request.params.get("page", 1))
+        per_page = int(request.params.get("per_page", 20))
 
         # Paginate the query
         total = query_result.count()
         items = query_result.offset((page - 1) * per_page).limit(per_page).all()
 
         return {
-            'items': items,  # Will be serialized by their own adapters
-            'pagination': {
-                'page': page,
-                'per_page': per_page,
-                'total': total,
-                'pages': (total + per_page - 1) // per_page,
-                'has_next': page * per_page < total,
-                'has_prev': page > 1
-            }
+            "items": items,  # Will be serialized by their own adapters
+            "pagination": {
+                "page": page,
+                "per_page": per_page,
+                "total": total,
+                "pages": (total + per_page - 1) // per_page,
+                "has_next": page * per_page < total,
+                "has_prev": page > 1,
+            },
         }
 
 Error Response JSON
@@ -401,40 +401,40 @@ Standardize error responses:
 
     from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound
 
+
     class APIError(Exception):
         def __init__(self, message, code=None, details=None):
             self.message = message
             self.code = code
             self.details = details or {}
 
+
     def api_error_adapter(error, request):
         """Serialize API errors consistently."""
         return {
-            'error': {
-                'message': error.message,
-                'code': error.code,
-                'details': error.details,
-                'timestamp': datetime.utcnow().isoformat()
+            "error": {
+                "message": error.message,
+                "code": error.code,
+                "details": error.details,
+                "timestamp": datetime.utcnow().isoformat(),
             }
         }
+
 
     def error_view(request):
         """Handle API errors."""
         try:
             # Your business logic
             result = do_something()
-            return {'data': result}
+            return {"data": result}
         except ValidationError as e:
             raise APIError(
                 message="Validation failed",
                 code="VALIDATION_ERROR",
-                details={'field_errors': e.errors}
+                details={"field_errors": e.errors},
             )
         except PermissionError:
-            raise APIError(
-                message="Permission denied",
-                code="PERMISSION_DENIED"
-            )
+            raise APIError(message="Permission denied", code="PERMISSION_DENIED")
 
 Performance Optimization
 ========================
@@ -448,17 +448,20 @@ Lazy Loading with JSON
 
     from sqlalchemy.orm import load_only
 
-    @view_config(route_name='users_api', renderer='json')
+
+    @view_config(route_name="users_api", renderer="json")
     def users_api_light(request):
         """Optimized user listing - only load needed fields."""
         session = request.dbsession
 
         # Only load fields we'll serialize
-        users = session.query(User).options(
-            load_only(User.id, User.username, User.email, User.created_at)
-        ).all()
+        users = (
+            session.query(User)
+            .options(load_only(User.id, User.username, User.email, User.created_at))
+            .all()
+        )
 
-        return {'users': users}
+        return {"users": users}
 
 Caching JSON Responses
 ----------------------
@@ -469,22 +472,21 @@ Caching JSON Responses
     from pyramid.response import Response
     import json
 
+
     @lru_cache(maxsize=100)
     def get_cached_stats():
         """Cache expensive statistics calculation."""
         # Expensive computation
         return calculate_complex_stats()
 
-    @view_config(route_name='stats_api')
+
+    @view_config(route_name="stats_api")
     def stats_api(request):
         """Cached JSON response."""
         stats = get_cached_stats()
 
         # Manual JSON response with caching headers
-        response = Response(
-            body=json.dumps(stats),
-            content_type='application/json'
-        )
+        response = Response(body=json.dumps(stats), content_type="application/json")
         response.cache_control.max_age = 300  # 5 minutes
         return response
 
@@ -508,34 +510,31 @@ Input Validation
                 "type": "string",
                 "minLength": 3,
                 "maxLength": 50,
-                "pattern": "^[a-zA-Z0-9_]+$"
+                "pattern": "^[a-zA-Z0-9_]+$",
             },
-            "email": {
-                "type": "string",
-                "format": "email"
-            },
-            "age": {
-                "type": "integer",
-                "minimum": 13,
-                "maximum": 120
-            }
+            "email": {"type": "string", "format": "email"},
+            "age": {"type": "integer", "minimum": 13, "maximum": 120},
         },
         "required": ["username", "email"],
-        "additionalProperties": False
+        "additionalProperties": False,
     }
+
 
     def validate_json_input(data, schema):
         """Validate JSON data against schema."""
         try:
             jsonschema.validate(data, schema)
         except jsonschema.ValidationError as e:
-            raise HTTPBadRequest(json_body={
-                'error': 'Validation failed',
-                'details': e.message,
-                'path': list(e.absolute_path)
-            })
+            raise HTTPBadRequest(
+                json_body={
+                    "error": "Validation failed",
+                    "details": e.message,
+                    "path": list(e.absolute_path),
+                }
+            )
 
-    @view_config(route_name='create_user', request_method='POST', renderer='json')
+
+    @view_config(route_name="create_user", request_method="POST", renderer="json")
     def create_user(request):
         # Validate input
         validate_json_input(request.json_body, USER_CREATE_SCHEMA)
@@ -543,12 +542,12 @@ Input Validation
         # Create user with validated data
         user_data = request.json_body
         user = User(
-            username=user_data['username'],
-            email=user_data['email'],
-            age=user_data.get('age')
+            username=user_data["username"],
+            email=user_data["email"],
+            age=user_data.get("age"),
         )
 
-        return {'user': user}
+        return {"user": user}
 
 Testing JSON APIs
 =================
@@ -562,24 +561,25 @@ Basic JSON Testing
 
     def test_user_api(app):
         # Test successful response
-        response = app.get('/api/users/1')
+        response = app.get("/api/users/1")
         assert response.status_code == 200
-        assert response.content_type == 'application/json'
+        assert response.content_type == "application/json"
 
         data = response.json
-        assert 'id' in data
-        assert 'username' in data
-        assert 'password_hash' not in data  # Sensitive data excluded
+        assert "id" in data
+        assert "username" in data
+        assert "password_hash" not in data  # Sensitive data excluded
+
 
     def test_json_input_validation(app):
         # Test invalid JSON input
-        invalid_data = {'username': 'x'}  # Too short
+        invalid_data = {"username": "x"}  # Too short
 
-        response = app.post_json('/api/users', invalid_data, expect_errors=True)
+        response = app.post_json("/api/users", invalid_data, expect_errors=True)
         assert response.status_code == 400
 
         error_data = response.json
-        assert 'error' in error_data
+        assert "error" in error_data
 
 Custom JSON Assertions
 ----------------------
@@ -592,20 +592,23 @@ Custom JSON Assertions
         for key in expected_keys:
             assert key in data, f"Missing key: {key}"
 
+
     def assert_iso_datetime(datetime_string):
         """Assert string is valid ISO datetime."""
         from datetime import datetime
+
         try:
-            datetime.fromisoformat(datetime_string.replace('Z', '+00:00'))
+            datetime.fromisoformat(datetime_string.replace("Z", "+00:00"))
         except ValueError:
             raise AssertionError(f"Invalid ISO datetime: {datetime_string}")
 
+
     def test_user_json_structure(app):
-        response = app.get('/api/users/1')
+        response = app.get("/api/users/1")
         user_data = response.json
 
-        assert_json_structure(user_data, ['id', 'username', 'email', 'created_at'])
-        assert_iso_datetime(user_data['created_at'])
+        assert_json_structure(user_data, ["id", "username", "email", "created_at"])
+        assert_iso_datetime(user_data["created_at"])
 
 Best Practices
 ==============

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -23,6 +23,37 @@ Let's create a simple web application using Tet's enhanced features.
 Basic Application Structure
 ---------------------------
 
+You *can* keep an entire Tet application in a single module -- it is the
+quickest way to get a feel for the framework, and this tutorial does exactly
+that to keep each step short. A single file is perfectly fine for spikes,
+examples, and very small services.
+
+For anything you intend to maintain, though, organise the application as a
+Python **package** instead of a single file or one growing module. A package
+gives you a place for each concern (models, views, services, templates,
+migrations, tests) and makes ``config.scan()`` and asset specifications such as
+``"myapp:templates/home.tk"`` resolve cleanly. A typical layout looks like:
+
+.. code-block:: text
+
+    myapp/
+        myapp/
+            __init__.py        # main() application factory
+            models.py          # or a models/ package
+            views.py           # or a views/ package
+            services.py
+            templates/
+                home.tk
+            static/
+        development.ini
+        pyproject.toml
+        tests/
+
+The examples below use a flat ``app.py``/``models.py`` for brevity; when you
+move to a package, the same code lives in ``myapp/__init__.py``,
+``myapp/models.py`` and so on, and you start the app through the ``.ini`` file
+with ``pserve`` rather than a ``__main__`` block.
+
 Create a new directory for your project and add the following files:
 
 **app.py**
@@ -82,7 +113,7 @@ Let's enhance our application with database support using SQLAlchemy.
     from sqlalchemy import Column, Integer, String, DateTime, create_engine
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import sessionmaker
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     Base = declarative_base()
 
@@ -93,7 +124,7 @@ Let's enhance our application with database support using SQLAlchemy.
         id = Column(Integer, primary_key=True)
         name = Column(String(50), nullable=False)
         email = Column(String(100), unique=True, nullable=False)
-        created = Column(DateTime, default=datetime.utcnow)
+        created = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
         def __json__(self, request):
             """JSON serialization for Tet's JSON renderer."""
@@ -225,7 +256,7 @@ Let's add some security features to our application.
 
 Create a template that safely embeds JSON:
 
-**templates/users.pt** (Chameleon template)
+**templates/users.tk** (Tonnikala template)
 
 .. code-block:: html
 
@@ -233,7 +264,7 @@ Create a template that safely embeds JSON:
     <html>
     <head>
         <title>Users</title>
-        <meta name="csrf-token" content="${request.session.get_csrf_token()}">
+        <meta name="csrf-token" content="$request.session.get_csrf_token()">
     </head>
     <body>
         <h1>Users</h1>
@@ -241,7 +272,7 @@ Create a template that safely embeds JSON:
 
         <script>
             // Safe JSON embedding using Tet's js_safe_dumps
-            var users = ${users_json|n};
+            var users = $literal(users_json);
 
             // Display users
             var container = document.getElementById('users');

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -32,30 +32,35 @@ Create a new directory for your project and add the following files:
     from tet.config import application_factory, ALL_FEATURES
     from pyramid.response import Response
 
+
     def hello_world(request):
-        return Response('Hello, Tet!')
+        return Response("Hello, Tet!")
+
 
     def json_api(request):
         return {
-            'message': 'Hello from Tet API!',
-            'features': ['CSRF Protection', 'Safe JSON', 'Enhanced Auth']
+            "message": "Hello from Tet API!",
+            "features": ["CSRF Protection", "Safe JSON", "Enhanced Auth"],
         }
+
 
     @application_factory(included_features=ALL_FEATURES)
     def main(config):
         """Tet application factory."""
         # Add routes
-        config.add_route('home', '/')
-        config.add_route('api', '/api')
+        config.add_route("home", "/")
+        config.add_route("api", "/api")
 
         # Add views
-        config.add_view(hello_world, route_name='home')
-        config.add_view(json_api, route_name='api', renderer='json')
+        config.add_view(hello_world, route_name="home")
+        config.add_view(json_api, route_name="api", renderer="json")
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         from wsgiref.simple_server import make_server
+
         app = main({})  # Empty global_config
-        server = make_server('0.0.0.0', 6543, app)
+        server = make_server("0.0.0.0", 6543, app)
         print("Server running on http://localhost:6543")
         server.serve_forever()
 
@@ -81,8 +86,9 @@ Let's enhance our application with database support using SQLAlchemy.
 
     Base = declarative_base()
 
+
     class User(Base):
-        __tablename__ = 'users'
+        __tablename__ = "users"
 
         id = Column(Integer, primary_key=True)
         name = Column(String(50), nullable=False)
@@ -92,14 +98,15 @@ Let's enhance our application with database support using SQLAlchemy.
         def __json__(self, request):
             """JSON serialization for Tet's JSON renderer."""
             return {
-                'id': self.id,
-                'name': self.name,
-                'email': self.email,
-                'created': self.created  # Automatically converted by Tet
+                "id": self.id,
+                "name": self.name,
+                "email": self.email,
+                "created": self.created,  # Automatically converted by Tet
             }
 
+
     # Database setup
-    engine = create_engine('sqlite:///tutorial.db', echo=True)
+    engine = create_engine("sqlite:///tutorial.db", echo=True)
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
 
@@ -113,8 +120,10 @@ Let's enhance our application with database support using SQLAlchemy.
     from sqlalchemy.orm import Session
     from models import User
 
+
     def hello_world(request):
-        return Response('Hello, Tet!')
+        return Response("Hello, Tet!")
+
 
     class UserViews:
         """User management views."""
@@ -127,45 +136,49 @@ Let's enhance our application with database support using SQLAlchemy.
             # Transaction managed automatically by pyramid_tm
 
             # Create a new user
-            user = User(
-                name='John Doe',
-                email='john@example.com'
-            )
+            user = User(name="John Doe", email="john@example.com")
             self.dbsession.add(user)
             # No need to commit - pyramid_tm handles transactions automatically
 
-            return {'message': 'User created', 'user': user}
+            return {"message": "User created", "user": user}
 
         def list_users(self, request):
             # Use the autowired database session
             users = self.dbsession.query(User).all()
-            return {'users': users}
+            return {"users": users}
+
 
     @application_factory(included_features=ALL_FEATURES)
     def main(config):
         """Tet application factory with database support."""
         # Setup SQLAlchemy with automatic session management
-        config.include('tet.sqlalchemy.simple')
+        config.include("tet.sqlalchemy.simple")
         config.setup_sqlalchemy()
 
         # Routes
-        config.add_route('home', '/')
-        config.add_route('create_user', '/users/create')
-        config.add_route('list_users', '/users')
+        config.add_route("home", "/")
+        config.add_route("create_user", "/users/create")
+        config.add_route("list_users", "/users")
 
         # Views
-        config.add_view(hello_world, route_name='home')
+        config.add_view(hello_world, route_name="home")
 
         # Register class-based views
         user_views = UserViews()
-        config.add_view(user_views.create_user, route_name='create_user',
-                      request_method='POST', renderer='json')
-        config.add_view(user_views.list_users, route_name='list_users', renderer='json')
+        config.add_view(
+            user_views.create_user,
+            route_name="create_user",
+            request_method="POST",
+            renderer="json",
+        )
+        config.add_view(user_views.list_users, route_name="list_users", renderer="json")
 
-    if __name__ == '__main__':
+
+    if __name__ == "__main__":
         from wsgiref.simple_server import make_server
+
         app = main({})
-        server = make_server('0.0.0.0', 6543, app)
+        server = make_server("0.0.0.0", 6543, app)
         print("Server running on http://localhost:6543")
         server.serve_forever()
 
@@ -181,6 +194,7 @@ Let's add some security features to our application.
     from pyramid.httpexceptions import HTTPForbidden
     from pyramid.csrf import check_csrf_token
 
+
     def secure_create_user(request):
         # CSRF protection is automatically enabled
         # This view will require CSRF token for POST requests
@@ -189,23 +203,23 @@ Let's add some security features to our application.
             # Validate CSRF token (optional explicit check)
             check_csrf_token(request)
         except HTTPForbidden:
-            return {'error': 'CSRF token missing or invalid'}
+            return {"error": "CSRF token missing or invalid"}
 
-        session = request.find_service(name='dbsession')
+        session = request.find_service(name="dbsession")
 
         # Get data from request
-        name = request.json_body.get('name')
-        email = request.json_body.get('email')
+        name = request.json_body.get("name")
+        email = request.json_body.get("email")
 
         if not name or not email:
-            return {'error': 'Name and email are required'}
+            return {"error": "Name and email are required"}
 
         # Create user
         user = User(name=name, email=email)
         session.add(user)
         session.commit()
 
-        return {'message': 'User created successfully', 'user': user}
+        return {"message": "User created successfully", "user": user}
 
 **Safe JSON for Frontend**
 
@@ -246,8 +260,9 @@ Create a template that safely embeds JSON:
 
     from tet.util.json import js_safe_dumps
 
+
     def users_page(request):
-        session = request.find_service(name='dbsession')
+        session = request.find_service(name="dbsession")
         users = session.query(User).all()
 
         # Convert users to JSON-serializable format
@@ -256,7 +271,7 @@ Create a template that safely embeds JSON:
         # Safe JSON for template embedding
         users_json = js_safe_dumps(users_data)
 
-        return {'users_json': users_json}
+        return {"users_json": users_json}
 
 Adding Testing
 ==============
@@ -271,6 +286,7 @@ Let's add some tests for our application.
     from pyramid.testing import DummyRequest
     from models import User, Session, Base, engine
 
+
     @pytest.fixture
     def dbsession():
         """Create test database session."""
@@ -282,29 +298,28 @@ Let's add some tests for our application.
         session.close()
         Base.metadata.drop_all(engine)
 
+
     def test_create_user(dbsession):
         from app import create_user
 
         # Mock request with database session
         request = DummyRequest()
         request.find_service = lambda name: dbsession
-        request.json_body = {
-            'name': 'Test User',
-            'email': 'test@example.com'
-        }
+        request.json_body = {"name": "Test User", "email": "test@example.com"}
 
         # Test the view
         result = create_user(request)
 
-        assert result['message'] == 'User created'
-        assert result['user'].name == 'Test User'
+        assert result["message"] == "User created"
+        assert result["user"].name == "Test User"
+
 
     def test_list_users(dbsession):
         from app import list_users
 
         # Create test data
-        user1 = User(name='User 1', email='user1@example.com')
-        user2 = User(name='User 2', email='user2@example.com')
+        user1 = User(name="User 1", email="user1@example.com")
+        user2 = User(name="User 2", email="user2@example.com")
         dbsession.add_all([user1, user2])
         dbsession.commit()
 
@@ -315,7 +330,7 @@ Let's add some tests for our application.
         # Test the view
         result = list_users(request)
 
-        assert len(result['users']) == 2
+        assert len(result["users"]) == 2
 
 Run the tests::
 
@@ -381,10 +396,10 @@ For production deployment, create a proper configuration file.
     import os
 
     here = os.path.dirname(os.path.abspath(__file__))
-    config_file = os.path.join(here, 'production.ini')
+    config_file = os.path.join(here, "production.ini")
 
     setup_logging(config_file)
-    application = get_app(config_file, 'main')
+    application = get_app(config_file, "main")
 
 Deploy with gunicorn::
 

--- a/docs/tutorials/security_tutorial.rst
+++ b/docs/tutorials/security_tutorial.rst
@@ -38,7 +38,7 @@ Working with CSRF Tokens
 
     <form method="post" action="/submit">
         <input type="hidden" name="csrf_token"
-               value="${request.session.get_csrf_token()}">
+               value="$request.session.get_csrf_token()">
         <input type="text" name="data" placeholder="Enter data">
         <input type="submit" value="Submit">
     </form>
@@ -48,7 +48,7 @@ Working with CSRF Tokens
 .. code-block:: javascript
 
     // Set CSRF token in meta tag (in your template)
-    // <meta name="csrf-token" content="${request.session.get_csrf_token()}">
+    // <meta name="csrf-token" content="$request.session.get_csrf_token()">
 
     function setupCSRF() {
         var token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
@@ -293,7 +293,7 @@ In your template:
 
     <script>
         // This is safe from XSS attacks
-        var userData = ${user_json|n};
+        var userData = $literal(user_json);
 
         // Use the data safely
         document.getElementById('user-name').textContent = userData.name;

--- a/docs/tutorials/security_tutorial.rst
+++ b/docs/tutorials/security_tutorial.rst
@@ -18,10 +18,11 @@ Enable CSRF protection in your application:
 
     from pyramid.config import Configurator
 
+
     def main():
         with Configurator() as config:
             # Enable CSRF protection
-            config.include('tet.security.csrf')
+            config.include("tet.security.csrf")
 
             # CSRF is now required for all state-changing requests
             return config.make_wsgi_app()
@@ -79,14 +80,15 @@ Working with CSRF Tokens
     from pyramid.csrf import check_csrf_token
     from pyramid.httpexceptions import HTTPForbidden
 
+
     def secure_view(request):
         try:
             check_csrf_token(request)
         except HTTPForbidden:
-            return {'error': 'CSRF token missing or invalid'}
+            return {"error": "CSRF token missing or invalid"}
 
         # Process the request
-        return {'status': 'success'}
+        return {"status": "success"}
 
 Authorization System
 ====================
@@ -101,25 +103,25 @@ Creating an Authorization Policy
     from tet.security.authorization import INewAuthorizationPolicy
     from zope.interface import implementer
 
+
     @implementer(INewAuthorizationPolicy)
     class MyAuthorizationPolicy:
         def permits(self, request, context, principals, permission):
             """Check if any principal has the given permission."""
 
             # Access request data for authorization decisions
-            if permission == 'admin':
-                return 'group:admin' in principals
+            if permission == "admin":
+                return "group:admin" in principals
 
-            if permission == 'edit':
+            if permission == "edit":
                 # Context-specific authorization
-                if hasattr(context, 'owner_id'):
+                if hasattr(context, "owner_id"):
                     user_id = request.authenticated_userid
-                    return (context.owner_id == user_id or
-                           'group:admin' in principals)
+                    return context.owner_id == user_id or "group:admin" in principals
 
-            if permission == 'view':
+            if permission == "view":
                 # Public content
-                if hasattr(context, 'is_public') and context.is_public:
+                if hasattr(context, "is_public") and context.is_public:
                     return True
                 # Private content requires authentication
                 return request.authenticated_userid is not None
@@ -130,17 +132,17 @@ Creating an Authorization Policy
             """Return principals allowed for a permission."""
             allowed = set()
 
-            if permission == 'admin':
-                allowed.add('group:admin')
-            elif permission == 'edit':
-                if hasattr(context, 'owner_id'):
-                    allowed.add(f'user:{context.owner_id}')
-                allowed.add('group:admin')
-            elif permission == 'view':
-                if hasattr(context, 'is_public') and context.is_public:
-                    allowed.add('system.Everyone')
+            if permission == "admin":
+                allowed.add("group:admin")
+            elif permission == "edit":
+                if hasattr(context, "owner_id"):
+                    allowed.add(f"user:{context.owner_id}")
+                allowed.add("group:admin")
+            elif permission == "view":
+                if hasattr(context, "is_public") and context.is_public:
+                    allowed.add("system.Everyone")
                 else:
-                    allowed.add('system.Authenticated')
+                    allowed.add("system.Authenticated")
 
             return allowed
 
@@ -152,7 +154,7 @@ Registering the Authorization Policy
     def main():
         with Configurator() as config:
             # Include Tet's enhanced authorization
-            config.include('tet.security.authorization')
+            config.include("tet.security.authorization")
 
             # Register your policy
             config.set_authorization_policy(MyAuthorizationPolicy())
@@ -171,30 +173,31 @@ Using Authorization in Views
     from pyramid.httpexceptions import HTTPForbidden
     from pyramid.security import has_permission
 
-    @view_config(route_name='edit_post', renderer='json',
-                 permission='edit')
+
+    @view_config(route_name="edit_post", renderer="json", permission="edit")
     def edit_post(request):
         """This view requires 'edit' permission."""
-        post_id = request.matchdict['id']
+        post_id = request.matchdict["id"]
         post = get_post(post_id)
 
         # Permission is already checked by the view decorator
         # Update the post
-        post.title = request.json_body.get('title', post.title)
+        post.title = request.json_body.get("title", post.title)
 
-        return {'status': 'updated', 'post': post}
+        return {"status": "updated", "post": post}
 
-    @view_config(route_name='view_post', renderer='json')
+
+    @view_config(route_name="view_post", renderer="json")
     def view_post(request):
         """Manual permission checking."""
-        post_id = request.matchdict['id']
+        post_id = request.matchdict["id"]
         post = get_post(post_id)
 
         # Check permission manually
-        if not has_permission('view', post, request):
+        if not has_permission("view", post, request):
             raise HTTPForbidden("You don't have permission to view this post")
 
-        return {'post': post}
+        return {"post": post}
 
 Authentication Integration
 ==========================
@@ -208,30 +211,30 @@ Using pyramid_jwt
 
     from pyramid_jwt import create_jwt_authentication_policy
 
+
     def main():
         with Configurator() as config:
             # JWT Authentication
-            config.include('pyramid_jwt')
+            config.include("pyramid_jwt")
             config.set_jwt_authentication_policy(
-                'secret_key',
-                auth_type='Bearer',
-                callback=get_user_from_jwt
+                "secret_key", auth_type="Bearer", callback=get_user_from_jwt
             )
 
             # Tet Authorization
-            config.include('tet.security.authorization')
+            config.include("tet.security.authorization")
             config.set_authorization_policy(MyAuthorizationPolicy())
 
             return config.make_wsgi_app()
+
 
     def get_user_from_jwt(userid, request):
         """Get user principals from JWT payload."""
         # Your user lookup logic
         user = get_user(userid)
         if user and user.is_active:
-            principals = [f'user:{user.id}']
+            principals = [f"user:{user.id}"]
             if user.is_admin:
-                principals.append('group:admin')
+                principals.append("group:admin")
             return principals
         return None
 
@@ -251,10 +254,10 @@ Creating Protected Resources
         def __acl__(self):
             """Access Control List for this resource."""
             return [
-                (Allow, f'user:{self.owner_id}', 'edit'),
-                (Allow, f'user:{self.owner_id}', 'delete'),
-                (Allow, 'group:admin', ALL_PERMISSIONS),
-                (Allow, Everyone, 'view') if self.is_public else (Deny, Everyone, 'view'),
+                (Allow, f"user:{self.owner_id}", "edit"),
+                (Allow, f"user:{self.owner_id}", "delete"),
+                (Allow, "group:admin", ALL_PERMISSIONS),
+                (Allow, Everyone, "view") if self.is_public else (Deny, Everyone, "view"),
             ]
 
 Safe Data Handling
@@ -271,17 +274,18 @@ Prevent XSS attacks when embedding JSON in HTML:
 
     from tet.util.json import js_safe_dumps
 
+
     def user_profile_page(request):
         user_data = {
-            'name': request.user.name,
-            'bio': request.user.bio,  # Could contain HTML
-            'preferences': request.user.preferences
+            "name": request.user.name,
+            "bio": request.user.bio,  # Could contain HTML
+            "preferences": request.user.preferences,
         }
 
         # Safe for embedding in HTML/JavaScript
         safe_json = js_safe_dumps(user_data)
 
-        return {'user_json': safe_json}
+        return {"user_json": safe_json}
 
 In your template:
 
@@ -303,6 +307,7 @@ Input Validation and Sanitization
     import re
     from html import escape
 
+
     def sanitize_user_input(data):
         """Sanitize user input data."""
         sanitized = {}
@@ -310,7 +315,7 @@ Input Validation and Sanitization
         for key, value in data.items():
             if isinstance(value, str):
                 # Remove potentially dangerous characters
-                value = re.sub(r'[<>"\']', '', value)
+                value = re.sub(r'[<>"\']', "", value)
                 # Escape HTML entities
                 value = escape(value)
                 # Limit length
@@ -320,8 +325,13 @@ Input Validation and Sanitization
 
         return sanitized
 
-    @view_config(route_name='update_profile', request_method='POST',
-                 renderer='json', permission='edit')
+
+    @view_config(
+        route_name="update_profile",
+        request_method="POST",
+        renderer="json",
+        permission="edit",
+    )
     def update_profile(request):
         # Sanitize input data
         raw_data = request.json_body
@@ -329,10 +339,10 @@ Input Validation and Sanitization
 
         # Update user profile with clean data
         user = request.user
-        user.bio = clean_data.get('bio', user.bio)
-        user.website = clean_data.get('website', user.website)
+        user.bio = clean_data.get("bio", user.bio)
+        user.website = clean_data.get("website", user.website)
 
-        return {'status': 'updated'}
+        return {"status": "updated"}
 
 Session Security
 ================
@@ -346,18 +356,20 @@ Session Configuration
 
     def main(global_config, **settings):
         # Production session settings
-        settings.update({
-            'session.secret': 'your-very-secure-secret-key',
-            'session.secure': True,      # HTTPS only
-            'session.httponly': True,    # No JavaScript access
-            'session.samesite': 'Strict', # CSRF protection
-            'session.timeout': 3600,     # 1 hour timeout
-            'session.cookie_max_age': 86400,  # 24 hours
-        })
+        settings.update(
+            {
+                "session.secret": "your-very-secure-secret-key",
+                "session.secure": True,  # HTTPS only
+                "session.httponly": True,  # No JavaScript access
+                "session.samesite": "Strict",  # CSRF protection
+                "session.timeout": 3600,  # 1 hour timeout
+                "session.cookie_max_age": 86400,  # 24 hours
+            }
+        )
 
         with Configurator(settings=settings) as config:
-            config.include('pyramid_session')
-            config.include('tet.security.csrf')
+            config.include("pyramid_session")
+            config.include("tet.security.csrf")
 
             return config.make_wsgi_app()
 
@@ -378,18 +390,21 @@ Simple Rate Limiting
     # Simple in-memory rate limiter (use Redis in production)
     request_counts = {}
 
+
     def rate_limit(max_requests=10, window=60):
         """Rate limiting decorator."""
+
         def decorator(func):
             @wraps(func)
             def wrapper(request):
-                client_ip = request.environ.get('REMOTE_ADDR')
+                client_ip = request.environ.get("REMOTE_ADDR")
                 current_time = time()
 
                 # Clean old entries
                 cutoff = current_time - window
                 request_counts[client_ip] = [
-                    timestamp for timestamp in request_counts.get(client_ip, [])
+                    timestamp
+                    for timestamp in request_counts.get(client_ip, [])
                     if timestamp > cutoff
                 ]
 
@@ -401,13 +416,16 @@ Simple Rate Limiting
                 request_counts[client_ip].append(current_time)
 
                 return func(request)
+
             return wrapper
+
         return decorator
 
-    @view_config(route_name='api_endpoint', renderer='json')
+
+    @view_config(route_name="api_endpoint", renderer="json")
     @rate_limit(max_requests=5, window=60)  # 5 requests per minute
     def api_endpoint(request):
-        return {'data': 'sensitive_information'}
+        return {"data": "sensitive_information"}
 
 Security Headers
 ================
@@ -426,25 +444,27 @@ Security Headers Middleware
             response = handler(request)
 
             # Security headers
-            response.headers.update({
-                'X-Content-Type-Options': 'nosniff',
-                'X-Frame-Options': 'DENY',
-                'X-XSS-Protection': '1; mode=block',
-                'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
-                'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'",
-                'Referrer-Policy': 'strict-origin-when-cross-origin'
-            })
+            response.headers.update(
+                {
+                    "X-Content-Type-Options": "nosniff",
+                    "X-Frame-Options": "DENY",
+                    "X-XSS-Protection": "1; mode=block",
+                    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+                    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline'",
+                    "Referrer-Policy": "strict-origin-when-cross-origin",
+                }
+            )
 
             return response
 
         return security_headers_tween
 
+
     def main():
         with Configurator() as config:
             # Add security headers tween
             config.add_tween(
-                'myapp.security_headers_tween_factory',
-                under='pyramid_tm.tm_tween_factory'
+                "myapp.security_headers_tween_factory", under="pyramid_tm.tm_tween_factory"
             )
 
             return config.make_wsgi_app()
@@ -461,12 +481,11 @@ Testing CSRF Protection
 
     def test_csrf_protection(app):
         # GET request should work
-        response = app.get('/form')
+        response = app.get("/form")
         assert response.status_code == 200
 
         # POST without CSRF token should fail
-        response = app.post('/submit', {'data': 'test'},
-                          expect_errors=True)
+        response = app.post("/submit", {"data": "test"}, expect_errors=True)
         assert response.status_code == 403
 
         # POST with CSRF token should work
@@ -485,13 +504,13 @@ Testing Authorization
         request = DummyRequest()
 
         # Test admin permission
-        assert policy.permits(request, None, ['group:admin'], 'admin')
-        assert not policy.permits(request, None, ['user:123'], 'admin')
+        assert policy.permits(request, None, ["group:admin"], "admin")
+        assert not policy.permits(request, None, ["user:123"], "admin")
 
         # Test context-specific permission
         context = Mock(owner_id=123, is_public=False)
-        assert policy.permits(request, context, ['user:123'], 'edit')
-        assert not policy.permits(request, context, ['user:456'], 'edit')
+        assert policy.permits(request, context, ["user:123"], "edit")
+        assert not policy.permits(request, context, ["user:456"], "edit")
 
 Security Checklist
 ==================

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -1,0 +1,45 @@
+"""Compile-check every Python ``code-block`` example in the documentation.
+
+Each ``.. code-block:: python`` snippet under ``docs/`` is extracted and passed
+through :func:`compile`, so syntactically broken examples (or ones the doc
+tooling mangles) fail CI. A snippet can opt out with a
+``.. doc-example: no-compile`` comment immediately before its directive.
+
+This does not *run* the examples -- many are deliberately partial -- it only
+guarantees they are valid Python that parses and compiles.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS = REPO_ROOT / "docs"
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from doc_examples import iter_python_examples, iter_rst_files  # noqa: E402
+
+
+def _collect():
+    examples = []
+    for path in iter_rst_files([str(DOCS)]):
+        text = path.read_text(encoding="utf-8")
+        examples.extend(iter_python_examples(text, path))
+    return examples
+
+
+EXAMPLES = _collect()
+IDS = [f"{ex.path.relative_to(REPO_ROOT)}:{ex.lineno}" for ex in EXAMPLES]
+
+
+def test_examples_were_found():
+    # Guard against the extractor silently breaking and "passing" zero examples.
+    assert len(EXAMPLES) > 100
+
+
+@pytest.mark.parametrize("example", EXAMPLES, ids=IDS)
+def test_doc_example_compiles(example):
+    if example.no_compile:
+        pytest.skip("marked .. doc-example: no-compile")
+    compile(example.code, str(example.path.relative_to(REPO_ROOT)), "exec")

--- a/tools/doc_examples.py
+++ b/tools/doc_examples.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Extract (and compile-check) Python ``code-block`` examples in RST docs.
+
+Shared by :mod:`tools.format_doc_examples` (which ruff-formats the examples) and
+``tests/test_doc_examples.py`` (which compile-checks them). Pure standard
+library so it imports cleanly under pytest with no extra dependencies.
+
+Run directly to compile-check every example (used as a pre-commit gate)::
+
+    tools/doc_examples.py            # checks docs/
+    tools/doc_examples.py docs/narr  # checks a subset
+
+A snippet can opt out of compile-checking with a ``.. doc-example: no-compile``
+comment on the line immediately before the ``.. code-block:: python`` directive,
+for intentionally partial fragments.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+DIRECTIVE_RE = re.compile(r"^(?P<indent>[ \t]*)\.\. code-block:: *python3?\s*$")
+OPTION_RE = re.compile(r"^(?P<indent>[ \t]*):[\w-]+:")
+NO_COMPILE_RE = re.compile(r"^\s*\.\. doc-example: *no-compile\s*$")
+
+
+class Example(NamedTuple):
+    """One extracted Python code block."""
+
+    path: Path
+    lineno: int  # 1-based line of the first body line
+    code: str  # dedented snippet text
+    no_compile: bool  # opted out of compile-checking
+
+
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def iter_python_examples(text: str, path: Path) -> Iterator[Example]:
+    """Yield each ``.. code-block:: python`` body found in *text*, dedented."""
+    lines = text.split("\n")
+    n = len(lines)
+    i = 0
+    while i < n:
+        m = DIRECTIVE_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+
+        no_compile = i > 0 and bool(NO_COMPILE_RE.match(lines[i - 1]))
+        base = len(m.group("indent"))
+        i += 1
+
+        # Skip directive options (e.g. :caption:) and blank lines.
+        while i < n:
+            cur = lines[i]
+            if cur.strip() == "":
+                i += 1
+                continue
+            mo = OPTION_RE.match(cur)
+            if mo and len(mo.group("indent")) > base:
+                i += 1
+                continue
+            break
+
+        # Collect the indented body.
+        body_start = i + 1
+        body: list[str] = []
+        while i < n:
+            cur = lines[i]
+            if cur.strip() == "" or _indent_of(cur) > base:
+                body.append(cur)
+                i += 1
+                continue
+            break
+
+        while body and body[-1].strip() == "":
+            body.pop()
+        nonblank = [b for b in body if b.strip()]
+        if not nonblank:
+            continue
+
+        body_indent = min(_indent_of(b) for b in nonblank)
+        code = "\n".join(b[body_indent:] if b.strip() else "" for b in body)
+        yield Example(path=path, lineno=body_start, code=code, no_compile=no_compile)
+
+
+def iter_rst_files(paths: list[str]) -> Iterator[Path]:
+    for raw in paths:
+        p = Path(raw)
+        if p.is_dir():
+            yield from sorted(p.rglob("*.rst"))
+        elif p.suffix == ".rst":
+            yield p
+
+
+def main(argv: list[str]) -> int:
+    """Compile-check every example under the given paths (default ``docs``)."""
+    paths = argv or ["docs"]
+    total = 0
+    skipped = 0
+    failures = []
+    for path in iter_rst_files(paths):
+        text = path.read_text(encoding="utf-8")
+        for ex in iter_python_examples(text, path):
+            total += 1
+            if ex.no_compile:
+                skipped += 1
+                continue
+            try:
+                compile(ex.code, f"{ex.path}:{ex.lineno}", "exec")
+            except SyntaxError as exc:
+                failures.append((ex.path, ex.lineno, exc.msg))
+
+    for p, lineno, msg in failures:
+        print(f"{p}:{lineno}: does not compile: {msg}", file=sys.stderr)
+
+    print(f"checked {total} example(s) ({skipped} skipped, {len(failures)} failed)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/format_doc_examples.py
+++ b/tools/format_doc_examples.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = ["ruff==0.4.4"]
+# ///
+"""Format the Python ``code-block`` examples embedded in reStructuredText docs.
+
+This is a small ``blacken-docs`` equivalent that uses **ruff** (not black) so the
+examples in our documentation are formatted exactly like the rest of the source
+tree (same ``ruff format`` rules, same pinned ruff version as the pre-commit
+``ruff-format`` hook).
+
+Usage::
+
+    # Reformat every example in docs/ in place
+    tools/format_doc_examples.py
+
+    # Only report which examples are not formatted (CI / pre-commit); exit 1 if any
+    tools/format_doc_examples.py --check
+
+    # Restrict to specific files or directories
+    tools/format_doc_examples.py docs/narr/services.rst
+
+Only ``.. code-block:: python`` (and ``python3``) blocks are touched. Snippets
+that ruff cannot parse (intentional fragments) are left untouched and reported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DIRECTIVE_RE = re.compile(r"^(?P<indent>[ \t]*)\.\. code-block:: *python3?\s*$")
+OPTION_RE = re.compile(r"^(?P<indent>[ \t]*):[\w-]+:")
+
+RUFF = shutil.which("ruff")
+
+
+def ruff_format(code: str, stdin_filename: Path) -> str | None:
+    """Format a snippet with ruff. Return formatted text, or None if unparseable."""
+    if RUFF is None:
+        sys.exit("error: could not find the 'ruff' executable on PATH")
+    proc = subprocess.run(
+        [RUFF, "format", "-", "--stdin-filename", str(stdin_filename)],
+        input=code,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        # Most commonly a syntax error: an intentionally partial snippet.
+        return None
+    return proc.stdout
+
+
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def process_text(text: str, path: Path):
+    """Return (new_text, formatted_count, skipped) for one document."""
+    lines = text.split("\n")
+    n = len(lines)
+    out: list[str] = []
+    formatted_count = 0
+    skipped: list[int] = []
+    i = 0
+    while i < n:
+        line = lines[i]
+        m = DIRECTIVE_RE.match(line)
+        if not m:
+            out.append(line)
+            i += 1
+            continue
+
+        base = len(m.group("indent"))
+        out.append(line)
+        i += 1
+
+        # Pass through directive options (e.g. :caption:) and the blank line(s).
+        while i < n:
+            cur = lines[i]
+            if cur.strip() == "":
+                out.append(cur)
+                i += 1
+                continue
+            mo = OPTION_RE.match(cur)
+            if mo and len(mo.group("indent")) > base:
+                out.append(cur)
+                i += 1
+                continue
+            break
+
+        # Collect the indented body of the code block.
+        body_start = i + 1  # 1-based line number of first body line
+        body: list[str] = []
+        while i < n:
+            cur = lines[i]
+            if cur.strip() == "":
+                body.append(cur)
+                i += 1
+                continue
+            if _indent_of(cur) > base:
+                body.append(cur)
+                i += 1
+                continue
+            break
+
+        # Split trailing blank lines off — they sit between this block and the next.
+        trailing: list[str] = []
+        while body and body[-1].strip() == "":
+            trailing.insert(0, body.pop())
+
+        nonblank = [b for b in body if b.strip()]
+        if not nonblank:
+            out.extend(body)
+            out.extend(trailing)
+            continue
+
+        body_indent = min(_indent_of(b) for b in nonblank)
+        code = "\n".join(b[body_indent:] if b.strip() else "" for b in body)
+        formatted = ruff_format(code + "\n", path)
+        if formatted is None:
+            skipped.append(body_start)
+            out.extend(body)
+            out.extend(trailing)
+            continue
+
+        prefix = " " * body_indent
+        new_body = [
+            (prefix + fl) if fl else "" for fl in formatted.rstrip("\n").split("\n")
+        ]
+        if new_body != body:
+            formatted_count += 1
+        out.extend(new_body)
+        out.extend(trailing)
+
+    return "\n".join(out), formatted_count, skipped
+
+
+def iter_rst_files(paths: list[str]):
+    for raw in paths:
+        p = Path(raw)
+        if p.is_dir():
+            yield from sorted(p.rglob("*.rst"))
+        elif p.suffix == ".rst":
+            yield p
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["docs"],
+        help="RST files or directories to process (default: docs/)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="do not write files; exit 1 if any example would be reformatted",
+    )
+    args = parser.parse_args()
+
+    total_changed = 0
+    changed_files = 0
+    total_skipped = 0
+    for path in iter_rst_files(args.paths):
+        original = path.read_text(encoding="utf-8")
+        new_text, count, skipped = process_text(original, path)
+        if skipped:
+            total_skipped += len(skipped)
+            locs = ", ".join(f"{path}:{ln}" for ln in skipped)
+            print(f"skip (unparseable, left as-is): {locs}", file=sys.stderr)
+        if count:
+            total_changed += count
+            changed_files += 1
+            if args.check:
+                print(f"would reformat {count} example(s) in {path}")
+            else:
+                path.write_text(new_text, encoding="utf-8")
+                print(f"reformatted {count} example(s) in {path}")
+
+    if args.check:
+        if total_changed:
+            print(
+                f"\n{total_changed} example(s) in {changed_files} file(s) need formatting"
+            )
+            return 1
+        print("all doc examples are formatted")
+        return 0
+
+    print(
+        f"\ndone: {total_changed} example(s) reformatted in {changed_files} file(s)"
+        f"; {total_skipped} unparseable snippet(s) skipped"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/format_doc_examples.py
+++ b/tools/format_doc_examples.py
@@ -28,14 +28,19 @@ that ruff cannot parse (intentional fragments) are left untouched and reported.
 from __future__ import annotations
 
 import argparse
-import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-DIRECTIVE_RE = re.compile(r"^(?P<indent>[ \t]*)\.\. code-block:: *python3?\s*$")
-OPTION_RE = re.compile(r"^(?P<indent>[ \t]*):[\w-]+:")
+# Share the RST code-block parsing with the compile-check tooling/tests.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from doc_examples import (  # noqa: E402,I001
+    DIRECTIVE_RE,
+    OPTION_RE,
+    _indent_of,
+    iter_rst_files,
+)
 
 RUFF = shutil.which("ruff")
 
@@ -54,10 +59,6 @@ def ruff_format(code: str, stdin_filename: Path) -> str | None:
         # Most commonly a syntax error: an intentionally partial snippet.
         return None
     return proc.stdout
-
-
-def _indent_of(line: str) -> int:
-    return len(line) - len(line.lstrip())
 
 
 def process_text(text: str, path: Path):
@@ -139,15 +140,6 @@ def process_text(text: str, path: Path):
         out.extend(trailing)
 
     return "\n".join(out), formatted_count, skipped
-
-
-def iter_rst_files(paths: list[str]):
-    for raw in paths:
-        p = Path(raw)
-        if p.is_dir():
-            yield from sorted(p.rglob("*.rst"))
-        elif p.suffix == ".rst":
-            yield p
 
 
 def main() -> int:


### PR DESCRIPTION
## Documentation correctness & tooling

Three related fixes to the narrative/tutorial docs, plus tooling to keep them honest.

### 1. ruff-format every example (`f9e703e`)
All 196 `code-block:: python` examples are now formatted exactly like the source tree. Adds **`tools/format_doc_examples.py`** — a self-contained `uv` script that extracts each example, runs it through `ruff format` (pinned `ruff==0.4.4`, matching the `ruff-format` pre-commit hook), and reindents it back into the RST. Supports `--check`; wired in as a pre-commit hook over `docs/**.rst`. 113 examples reformatted.

### 2. Correct template syntax, datetimes, project layout (`8eb4452`)
- **Tonnikala, not Chameleon.** Replaced the Chameleon `|n` no-escape filter with Tonnikala's `$literal(...)`, renamed `.pt`/`.html` renderer targets to `.tk`, dropped the "Chameleon template" labels, and switched attribute/call chains (CSRF token, `static_url`) to bare `$` interpolation to match `templating.rst`.
- **Timezone-aware datetimes.** Replaced `datetime.utcnow` with `datetime.now(timezone.utc)` across the tutorials (and added a missing `datetime` import the JSON error-adapter example needed).
- **Single file vs package.** The quickstart now says a single file is fine for small apps, but real applications should be organised as a package, with a recommended layout.

### 3. Compile-check every example (`05137fe`)
Adds **`tools/doc_examples.py`** (stdlib RST extractor, shared with the formatter) and **`tests/test_doc_examples.py`**, which `compile()`s all 196 examples so syntactically broken or tooling-mangled snippets fail CI. Also a `compile-doc-examples` pre-commit hook. Snippets can opt out with `.. doc-example: no-compile`.

### Verification
- `rstcheck` clean across `docs/`
- `tests/test_doc_examples.py`: **197 passed**
- both new pre-commit hooks pass
- `ruff check` / `ruff format --check` clean (pinned 0.4.4)

https://claude.ai/code/session_011KKd5BtHMWfrF9WRRMwg7F
